### PR TITLE
feat(cms): implement hero block editor with validation and link targets

### DIFF
--- a/app/features/cms/blocks/block-ref.test.ts
+++ b/app/features/cms/blocks/block-ref.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  refByDefinitionKey,
+  refByPageBlockId,
+  type BlockRef,
+  type DefinitionKeyRef,
+  type PageBlockIdRef,
+} from "./block-ref";
+
+describe("BlockRef", () => {
+  test("refByDefinitionKey creates a DefinitionKeyRef", () => {
+    const ref = refByDefinitionKey("hero-main");
+
+    expect(ref.kind).toBe("definition-key");
+    expect(ref.definitionKey).toBe("hero-main");
+  });
+
+  test("refByPageBlockId creates a PageBlockIdRef with position", () => {
+    const ref = refByPageBlockId("clx123abc", 0);
+
+    expect(ref.kind).toBe("page-block-id");
+    expect(ref.pageBlockId).toBe("clx123abc");
+    expect(ref.position).toBe(0);
+  });
+
+  test("discriminated union narrows correctly in a switch", () => {
+    const refs: BlockRef[] = [
+      refByDefinitionKey("hero-main"),
+      refByPageBlockId("clx999", 2),
+    ];
+
+    const labels = refs.map((ref) => {
+      switch (ref.kind) {
+        case "definition-key":
+          return `dk:${ref.definitionKey}`;
+        case "page-block-id":
+          return `id:${ref.pageBlockId}@${ref.position}`;
+      }
+    });
+
+    expect(labels).toEqual(["dk:hero-main", "id:clx999@2"]);
+  });
+
+  test("DefinitionKeyRef and PageBlockIdRef are distinct types", () => {
+    const defRef: DefinitionKeyRef = refByDefinitionKey("slot-a");
+    const idRef: PageBlockIdRef = refByPageBlockId("abc", 1);
+
+    expect(defRef.kind).not.toBe(idRef.kind);
+  });
+});

--- a/app/features/cms/blocks/block-ref.ts
+++ b/app/features/cms/blocks/block-ref.ts
@@ -1,0 +1,25 @@
+export type DefinitionKeyRef = {
+  readonly kind: "definition-key";
+  readonly definitionKey: string;
+};
+
+export type PageBlockIdRef = {
+  readonly kind: "page-block-id";
+  readonly pageBlockId: string;
+  readonly position: number;
+};
+
+export type BlockRef = DefinitionKeyRef | PageBlockIdRef;
+
+/** Targets a fixed/named block by its definition key. Valid before and after persistence. */
+export function refByDefinitionKey(definitionKey: string): DefinitionKeyRef {
+  return { kind: "definition-key", definitionKey };
+}
+
+/** Targets a persisted block by its DB id. Only valid after first persistence. */
+export function refByPageBlockId(
+  pageBlockId: string,
+  position: number,
+): PageBlockIdRef {
+  return { kind: "page-block-id", pageBlockId, position };
+}

--- a/app/features/cms/blocks/hero/editor-schema.ts
+++ b/app/features/cms/blocks/hero/editor-schema.ts
@@ -1,0 +1,95 @@
+import { z } from "zod/v4";
+
+import type { BlockRef } from "../block-ref";
+
+import { createHeroActionSchema, type HeroBlockType } from "./model";
+
+import type { LinkTargetRegistry } from "~/features/cms/link-targets";
+
+export type HeroBlockEditorFormShape = {
+  eyebrow: string;
+  headline: string;
+  description: string;
+  actions: [{ label: string; href: string }];
+};
+
+export type HeroBlockEditorFormValue = {
+  eyebrow?: string;
+  headline: string;
+  description?: string;
+  actions: [{ label: string; href: string }];
+};
+
+export function createHeroBlockEditorFormSchema(
+  linkTargetRegistry: LinkTargetRegistry,
+) {
+  return z.object({
+    eyebrow: z
+      .string()
+      .trim()
+      .optional()
+      .transform((value) => (value ? value : undefined)),
+    headline: z
+      .string({ error: "Headline is required" })
+      .trim()
+      .min(1, "Headline is required"),
+    description: z
+      .string()
+      .trim()
+      .optional()
+      .transform((value) => (value ? value : undefined)),
+    actions: z.tuple([
+      createHeroActionSchema(linkTargetRegistry).pick({
+        label: true,
+        href: true,
+      }),
+    ]),
+  });
+}
+
+export function getHeroBlockEditorDefaultValue(
+  data: HeroBlockType["data"],
+  linkTargetRegistry: LinkTargetRegistry,
+): HeroBlockEditorFormShape {
+  const action = data.actions[0];
+
+  return {
+    eyebrow: data.eyebrow ?? "",
+    headline: data.headline,
+    description: data.description ?? "",
+    actions: [
+      {
+        label: action?.label ?? "",
+        href: action?.href ?? linkTargetRegistry.targets[0]?.href ?? "",
+      },
+    ],
+  };
+}
+
+export function applyHeroBlockEditorValue(
+  currentData: HeroBlockType["data"],
+  value: HeroBlockEditorFormValue,
+): HeroBlockType["data"] {
+  return {
+    ...currentData,
+    eyebrow: value.eyebrow,
+    headline: value.headline,
+    description: value.description,
+    actions: [
+      {
+        ...(currentData.actions[0] ?? {}),
+        label: value.actions[0].label,
+        href: value.actions[0].href,
+      },
+    ],
+  };
+}
+
+export function getHeroBlockEditorFormId(blockRef: BlockRef) {
+  switch (blockRef.kind) {
+    case "definition-key":
+      return `hero-block-editor-${blockRef.definitionKey}`;
+    case "page-block-id":
+      return `hero-block-editor-${blockRef.pageBlockId}`;
+  }
+}

--- a/app/features/cms/blocks/hero/editor.test.tsx
+++ b/app/features/cms/blocks/hero/editor.test.tsx
@@ -1,0 +1,155 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { describe, expect, test } from "vitest";
+
+import type { BlockEditorContext } from "../../catalog";
+import { createLinkTargetRegistry } from "../../link-targets";
+import { createPageCommandBuilder } from "../../page-commands";
+import { refByDefinitionKey } from "../block-ref";
+
+import { HeroBlockEditor } from "./editor";
+import type { HeroBlockType } from "./model";
+
+function makeCtx(
+  overrides: Partial<BlockEditorContext<HeroBlockType["data"]>> = {},
+): BlockEditorContext<HeroBlockType["data"]> {
+  const data: HeroBlockType["data"] = {
+    eyebrow: "test eyebrow",
+    headline: "test headline",
+    description: "test description",
+    actions: [{ label: "Join", href: "/join" }],
+    image: { src: "/hero.jpg" },
+  };
+
+  return {
+    data,
+    blockRef: refByDefinitionKey("hero-main"),
+    commandBuilder: createPageCommandBuilder("home", null),
+    linkTargetRegistry: createLinkTargetRegistry([
+      { key: "dinners", label: "Dinners", href: "/dinners" },
+      { key: "join", label: "Join", href: "/join" },
+    ]),
+    capabilities: { canMoveUp: false, canMoveDown: false, canDelete: false },
+    ...overrides,
+  };
+}
+
+function render(element: React.ReactNode) {
+  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+describe("HeroBlockEditor", () => {
+  test("renders the headline field pre-populated with current data", () => {
+    const html = render(<HeroBlockEditor ctx={makeCtx()} />);
+
+    expect(html).toContain("test headline");
+  });
+
+  test("renders the eyebrow field pre-populated with current data", () => {
+    const html = render(<HeroBlockEditor ctx={makeCtx()} />);
+
+    expect(html).toContain("test eyebrow");
+  });
+
+  test("renders the CTA select with link target options", () => {
+    const html = render(<HeroBlockEditor ctx={makeCtx()} />);
+
+    expect(html).toContain("Dinners");
+    expect(html).toContain("Join");
+  });
+
+  test("renders nested CTA field names for robust form parsing", () => {
+    const html = render(<HeroBlockEditor ctx={makeCtx()} />);
+
+    expect(html).toContain('name="actions[0].label"');
+    expect(html).toContain('name="actions[0].href"');
+  });
+
+  test("renders the image src as read-only (not an editable input)", () => {
+    const html = render(<HeroBlockEditor ctx={makeCtx()} />);
+
+    // The image src should be visible but not in an <input type="text"> that could alter it
+    expect(html).toContain("/hero.jpg");
+    expect(html).not.toContain(`<input type="text" value="/hero.jpg"`);
+  });
+
+  test("shows move-up button when canMoveUp is true", () => {
+    const html = render(
+      <HeroBlockEditor
+        ctx={makeCtx({
+          capabilities: {
+            canMoveUp: true,
+            canMoveDown: false,
+            canDelete: false,
+          },
+        })}
+      />,
+    );
+
+    expect(html.toLowerCase()).toContain("move up");
+  });
+
+  test("does not show move-up button when canMoveUp is false", () => {
+    const html = render(
+      <HeroBlockEditor
+        ctx={makeCtx({
+          capabilities: {
+            canMoveUp: false,
+            canMoveDown: false,
+            canDelete: false,
+          },
+        })}
+      />,
+    );
+
+    expect(html.toLowerCase()).not.toContain("move up");
+  });
+
+  test("shows delete button when canDelete is true", () => {
+    const html = render(
+      <HeroBlockEditor
+        ctx={makeCtx({
+          capabilities: {
+            canMoveUp: false,
+            canMoveDown: false,
+            canDelete: true,
+          },
+        })}
+      />,
+    );
+
+    expect(html.toLowerCase()).toContain("delete");
+  });
+
+  test("renders a block-level error message when the route returns one", () => {
+    const html = render(
+      <HeroBlockEditor
+        ctx={makeCtx({
+          formState: {
+            lastResult: null,
+            errorMessage:
+              "Block could not be saved — please refresh and retry.",
+          },
+        })}
+      />,
+    );
+
+    expect(html).toContain("Block could not be saved");
+  });
+
+  test("does not show delete button when canDelete is false", () => {
+    const html = render(
+      <HeroBlockEditor
+        ctx={makeCtx({
+          capabilities: {
+            canMoveUp: false,
+            canMoveDown: false,
+            canDelete: false,
+          },
+        })}
+      />,
+    );
+
+    expect(html.toLowerCase()).not.toContain("delete");
+  });
+});

--- a/app/features/cms/blocks/hero/editor.tsx
+++ b/app/features/cms/blocks/hero/editor.tsx
@@ -1,0 +1,209 @@
+import {
+  getFormProps,
+  getInputProps,
+  getSelectProps,
+  getTextareaProps,
+  useForm,
+} from "@conform-to/react";
+import { getZodConstraint, parseWithZod } from "@conform-to/zod/v4";
+
+import type { BlockEditorContext } from "../../catalog";
+
+import {
+  createHeroBlockEditorFormSchema,
+  getHeroBlockEditorDefaultValue,
+  getHeroBlockEditorFormId,
+} from "./editor-schema";
+import type { HeroBlockType } from "./model";
+
+import { Field, SelectField, TextareaField } from "~/components/forms";
+import { Button } from "~/components/ui/button";
+
+type HeroBlockEditorProps = {
+  ctx: BlockEditorContext<HeroBlockType["data"]>;
+};
+
+export function HeroBlockEditor({ ctx }: HeroBlockEditorProps) {
+  const {
+    data,
+    blockRef,
+    commandBuilder,
+    linkTargetRegistry,
+    capabilities,
+    formState,
+  } = ctx;
+  const schema = createHeroBlockEditorFormSchema(linkTargetRegistry);
+  const formId = getHeroBlockEditorFormId(blockRef);
+  const [form, fields] = useForm({
+    id: formId,
+    lastResult: formState?.lastResult ?? null,
+    shouldValidate: "onBlur",
+    constraint: getZodConstraint(schema),
+    defaultValue: getHeroBlockEditorDefaultValue(data, linkTargetRegistry),
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema });
+    },
+  });
+  const actionFields = fields.actions.getFieldList();
+  const primaryAction = actionFields[0]?.getFieldset();
+
+  // Serialize the blockRef so the route action can reconstruct commands
+  const blockRefJson = JSON.stringify(blockRef);
+  const baseCommand = commandBuilder.setBlockData(blockRef, "hero", 1, data);
+
+  return (
+    <div className="flex flex-col gap-4 rounded-md border p-4">
+      <form
+        method="post"
+        className="flex flex-col gap-4"
+        {...getFormProps(form)}
+      >
+        <input type="hidden" name="intent" value="set-block-data" />
+        <input type="hidden" name="blockRef" value={blockRefJson} />
+        <input type="hidden" name="blockType" value="hero" />
+        <input type="hidden" name="blockVersion" value="1" />
+        <input
+          type="hidden"
+          name="baseRevision"
+          value={
+            baseCommand.baseRevision === null
+              ? ""
+              : String(baseCommand.baseRevision)
+          }
+        />
+
+        {formState?.errorMessage ? (
+          <p className="text-destructive text-sm">{formState.errorMessage}</p>
+        ) : null}
+
+        {form.errors?.length ? (
+          <p className="text-destructive text-sm">{form.errors.join(" ")}</p>
+        ) : null}
+
+        <p className="text-muted-foreground text-sm">
+          Image: <span>{data.image.src}</span> (read-only)
+        </p>
+
+        <Field
+          labelProps={{ children: "Eyebrow" }}
+          inputProps={{ ...getInputProps(fields.eyebrow, { type: "text" }) }}
+          errors={fields.eyebrow.errors}
+          className="flex flex-col gap-2"
+        />
+
+        <Field
+          labelProps={{ children: "Headline" }}
+          inputProps={{ ...getInputProps(fields.headline, { type: "text" }) }}
+          errors={fields.headline.errors}
+          className="flex flex-col gap-2"
+        />
+
+        <TextareaField
+          labelProps={{ children: "Subheadline" }}
+          textareaProps={{
+            ...getTextareaProps(fields.description),
+            rows: 3,
+          }}
+          errors={fields.description.errors}
+          className="flex flex-col gap-2"
+        />
+
+        {primaryAction ? (
+          <>
+            <Field
+              labelProps={{ children: "CTA Label" }}
+              inputProps={{
+                ...getInputProps(primaryAction.label, { type: "text" }),
+              }}
+              errors={primaryAction.label.errors}
+              className="flex flex-col gap-2"
+            />
+
+            <SelectField
+              labelProps={{ children: "CTA Destination" }}
+              selectProps={{
+                ...getSelectProps(primaryAction.href),
+                children: linkTargetRegistry.targets.map((target) => (
+                  <option key={target.key} value={target.href}>
+                    {target.label}
+                  </option>
+                )),
+                className:
+                  "focus-visible:border-0 flex h-9 w-full appearance-none rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground file:placeholder:text-foreground focus-visible:outline-hidden focus-visible:inset-ring-2 focus-visible:inset-ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+              }}
+              errors={primaryAction.href.errors}
+              className="flex flex-col gap-2"
+            ></SelectField>
+          </>
+        ) : null}
+
+        <Button type="submit" className="self-start">
+          Save block
+        </Button>
+      </form>
+
+      <div className="flex gap-2">
+        {capabilities.canMoveUp ? (
+          <form method="post">
+            <input type="hidden" name="intent" value="move-block-up" />
+            <input type="hidden" name="blockRef" value={blockRefJson} />
+            <input
+              type="hidden"
+              name="baseRevision"
+              value={
+                baseCommand.baseRevision === null
+                  ? ""
+                  : String(baseCommand.baseRevision)
+              }
+            />
+            <Button type="submit" variant="outline">
+              Move up
+            </Button>
+          </form>
+        ) : null}
+
+        {capabilities.canMoveDown ? (
+          <form method="post">
+            <input type="hidden" name="intent" value="move-block-down" />
+            <input type="hidden" name="blockRef" value={blockRefJson} />
+            <input
+              type="hidden"
+              name="baseRevision"
+              value={
+                baseCommand.baseRevision === null
+                  ? ""
+                  : String(baseCommand.baseRevision)
+              }
+            />
+            <Button type="submit" variant="outline">
+              Move down
+            </Button>
+          </form>
+        ) : null}
+
+        {capabilities.canDelete ? (
+          <form method="post">
+            <input type="hidden" name="intent" value="delete-block" />
+            <input type="hidden" name="blockRef" value={blockRefJson} />
+            <input
+              type="hidden"
+              name="baseRevision"
+              value={
+                baseCommand.baseRevision === null
+                  ? ""
+                  : String(baseCommand.baseRevision)
+              }
+            />
+            <Button
+              type="submit"
+              variant="outline"
+              className="text-destructive"
+            >
+              Delete block
+            </Button>
+          </form>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/features/cms/blocks/hero/index.ts
+++ b/app/features/cms/blocks/hero/index.ts
@@ -1,17 +1,26 @@
 import { createElement } from "react";
 
 import { defineBlockDefinition } from "../../catalog";
+import { siteLinkTargetRegistry } from "../../site-link-targets";
 export * from "./model";
 export * from "./view";
 
-import { HeroBlockDataSchema, type HeroBlockType } from "./model";
+import { HeroBlockEditor } from "./editor";
+import { createHeroBlockDataSchema, type HeroBlockType } from "./model";
 import { HeroBlockView } from "./view";
+
+const SafeHeroBlockDataSchema = createHeroBlockDataSchema(
+  siteLinkTargetRegistry,
+);
 
 export const heroBlockDefinition = defineBlockDefinition<HeroBlockType>({
   type: "hero",
   version: 1,
-  schema: HeroBlockDataSchema,
+  schema: SafeHeroBlockDataSchema,
   render(block) {
     return createElement(HeroBlockView, { blockData: block });
+  },
+  editor(ctx) {
+    return createElement(HeroBlockEditor, { ctx });
   },
 });

--- a/app/features/cms/blocks/hero/model.ts
+++ b/app/features/cms/blocks/hero/model.ts
@@ -1,18 +1,59 @@
 import { z } from "zod/v4";
 
+import type { LinkTargetRegistry } from "../../link-targets";
 import { ActionSchema, ImageSchema } from "../models";
 import type { BlockBaseType, BlockType, BlockVersion } from "../types";
 
 const BLOCK_TYPE: BlockType = "hero";
 const BLOCK_VERSION: BlockVersion = 1;
 
-export const HeroBlockDataSchema = z.object({
-  eyebrow: z.string().optional(),
-  headline: z.string(),
-  description: z.string().optional(),
-  actions: z.array(ActionSchema),
-  image: ImageSchema,
-});
+function optionalCopyFieldSchema() {
+  return z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value ? value : undefined));
+}
+
+function requiredCopyFieldSchema(fieldLabel: string) {
+  return z
+    .string({ error: `${fieldLabel} is required` })
+    .trim()
+    .min(1, `${fieldLabel} is required`);
+}
+
+export function createHeroActionSchema(
+  linkTargetRegistry?: LinkTargetRegistry,
+) {
+  const hrefSchema = requiredCopyFieldSchema("CTA destination");
+  const safeHrefSchema = linkTargetRegistry
+    ? hrefSchema.refine(
+        (href) => linkTargetRegistry.byHref[href] !== undefined,
+        "CTA destination must be one of the registered site links",
+      )
+    : hrefSchema;
+
+  return ActionSchema.extend({
+    label: requiredCopyFieldSchema("CTA label"),
+    href: safeHrefSchema,
+  });
+}
+
+export function createHeroBlockDataSchema(
+  linkTargetRegistry?: LinkTargetRegistry,
+) {
+  return z.object({
+    eyebrow: optionalCopyFieldSchema(),
+    headline: requiredCopyFieldSchema("Headline"),
+    description: optionalCopyFieldSchema(),
+    actions: z
+      .array(createHeroActionSchema(linkTargetRegistry))
+      .min(1, "At least one CTA is required"),
+    image: ImageSchema,
+  });
+}
+
+export const HeroBlockDataSchema = createHeroBlockDataSchema();
 
 export type HeroBlockType = BlockBaseType<
   typeof BLOCK_TYPE,

--- a/app/features/cms/blocks/types.ts
+++ b/app/features/cms/blocks/types.ts
@@ -4,6 +4,8 @@ export type DefinitionKey = string;
 
 export type BlockBaseType<T extends BlockType, V extends BlockVersion, D> = {
   definitionKey?: DefinitionKey;
+  /** DB primary key of the persisted PageBlock row. Present only after first persistence. */
+  pageBlockId?: string;
   type: T;
   version: V;
   data: D;

--- a/app/features/cms/catalog.ts
+++ b/app/features/cms/catalog.ts
@@ -1,12 +1,16 @@
+import type { SubmissionResult } from "@conform-to/react";
 import type React from "react";
 import type { ZodType } from "zod/v4";
 
+import type { BlockRef } from "./blocks/block-ref";
 import type {
   BlockBaseType,
   BlockType,
   BlockVersion,
   DefinitionKey,
 } from "./blocks/types";
+import type { LinkTargetRegistry } from "./link-targets";
+import type { PageCommandBuilder } from "./page-commands";
 
 export type PageKey = string;
 export type Provenance = "default" | "persisted";
@@ -42,11 +46,32 @@ export type PublicProjectionContext = {
   pathname: string;
 };
 
+export type BlockEditorCapabilities = {
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  canDelete: boolean;
+};
+
+export type BlockEditorFormState = {
+  readonly lastResult: SubmissionResult<string[]> | null;
+  readonly errorMessage: string | null;
+};
+
+export type BlockEditorContext<TData = unknown> = {
+  readonly data: TData;
+  readonly blockRef: BlockRef;
+  readonly commandBuilder: PageCommandBuilder;
+  readonly linkTargetRegistry: LinkTargetRegistry;
+  readonly capabilities: BlockEditorCapabilities;
+  readonly formState?: BlockEditorFormState;
+};
+
 export type BlockDefinition<TBlock extends BlockInstance = BlockInstance> = {
   type: TBlock["type"];
   version: TBlock["version"];
   schema: ZodType<TBlock["data"]>;
   render(block: TBlock): React.ReactNode;
+  editor?(ctx: BlockEditorContext<TBlock["data"]>): React.ReactNode;
 };
 
 export type PageDefinition = {
@@ -63,6 +88,7 @@ export type PageDefinition = {
 export type CmsCatalog = {
   listPageKeys(): readonly PageKey[];
   getBlockDefinition(blockType: BlockType): BlockDefinition;
+  getPageRule(pageKey: PageKey): PageRule;
   readPageSnapshot(pageKey: PageKey): PageSnapshot;
   projectPublic(
     snapshot: PageSnapshot,
@@ -132,6 +158,13 @@ export function createCmsCatalog({
         blockType,
         `Unknown Block Type: ${blockType}`,
       );
+    },
+    getPageRule(pageKey) {
+      return requireFromMap(
+        pageDefinitions,
+        pageKey,
+        `Unknown Page Key: ${pageKey}`,
+      ).rules;
     },
     readPageSnapshot,
     projectPublic(snapshot, context) {

--- a/app/features/cms/link-targets.test.ts
+++ b/app/features/cms/link-targets.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import { createLinkTargetRegistry } from "./link-targets";
+
+describe("createLinkTargetRegistry", () => {
+  test("exposes targets in registration order", () => {
+    const registry = createLinkTargetRegistry([
+      { key: "dinners", label: "Dinners", href: "/dinners" },
+      { key: "join", label: "Join", href: "/join" },
+    ]);
+
+    expect(registry.targets).toEqual([
+      { key: "dinners", label: "Dinners", href: "/dinners" },
+      { key: "join", label: "Join", href: "/join" },
+    ]);
+  });
+
+  test("byHref provides lookup by stored href value", () => {
+    const registry = createLinkTargetRegistry([
+      { key: "dinners", label: "Dinners", href: "/dinners" },
+      { key: "join", label: "Join", href: "/join" },
+    ]);
+
+    expect(registry.byHref["/dinners"]).toEqual({
+      key: "dinners",
+      label: "Dinners",
+      href: "/dinners",
+    });
+    expect(registry.byHref["/join"]).toEqual({
+      key: "join",
+      label: "Join",
+      href: "/join",
+    });
+    expect(registry.byHref["/unknown"]).toBeUndefined();
+  });
+
+  test("works with an empty target list", () => {
+    const registry = createLinkTargetRegistry([]);
+
+    expect(registry.targets).toEqual([]);
+    expect(registry.byHref).toEqual({});
+  });
+
+  test("supports optional external flag", () => {
+    const registry = createLinkTargetRegistry([
+      {
+        key: "instagram",
+        label: "Instagram",
+        href: "https://instagram.com",
+        external: true,
+      },
+    ]);
+
+    expect(registry.targets[0].external).toBe(true);
+    expect(registry.byHref["https://instagram.com"]?.external).toBe(true);
+  });
+});

--- a/app/features/cms/link-targets.ts
+++ b/app/features/cms/link-targets.ts
@@ -1,0 +1,23 @@
+export type LinkTargetKey = string;
+
+export type LinkTarget = {
+  key: LinkTargetKey;
+  label: string;
+  href: string;
+  external?: boolean;
+};
+
+export type LinkTargetRegistry = {
+  readonly targets: readonly LinkTarget[];
+  readonly byHref: Readonly<Record<string, LinkTarget>>;
+};
+
+export function createLinkTargetRegistry(
+  targets: readonly LinkTarget[],
+): LinkTargetRegistry {
+  const byHref: Record<string, LinkTarget> = {};
+  for (const target of targets) {
+    byHref[target.href] = target;
+  }
+  return { targets, byHref };
+}

--- a/app/features/cms/page-command-builder.test.ts
+++ b/app/features/cms/page-command-builder.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+
+import { refByDefinitionKey, refByPageBlockId } from "./blocks/block-ref";
+import { createPageCommandBuilder } from "./page-commands";
+
+describe("createPageCommandBuilder", () => {
+  test("setBlockData pre-binds pageKey and baseRevision", () => {
+    const builder = createPageCommandBuilder("home", 3);
+    const ref = refByDefinitionKey("hero-main");
+
+    const cmd = builder.setBlockData(ref, "hero", 1, { headline: "New title" });
+
+    expect(cmd).toEqual({
+      type: "set-block-data",
+      pageKey: "home",
+      baseRevision: 3,
+      ref,
+      blockType: "hero",
+      blockVersion: 1,
+      data: { headline: "New title" },
+    });
+  });
+
+  test("moveBlockUp pre-binds pageKey and baseRevision", () => {
+    const builder = createPageCommandBuilder("home", 1);
+    const ref = refByPageBlockId("clx123", 1);
+
+    const cmd = builder.moveBlockUp(ref);
+
+    expect(cmd).toEqual({
+      type: "move-block-up",
+      pageKey: "home",
+      baseRevision: 1,
+      ref,
+    });
+  });
+
+  test("moveBlockDown pre-binds pageKey and baseRevision", () => {
+    const builder = createPageCommandBuilder("home", 2);
+    const ref = refByPageBlockId("clx456", 0);
+
+    const cmd = builder.moveBlockDown(ref);
+
+    expect(cmd).toEqual({
+      type: "move-block-down",
+      pageKey: "home",
+      baseRevision: 2,
+      ref,
+    });
+  });
+
+  test("deleteBlock pre-binds pageKey and baseRevision", () => {
+    const builder = createPageCommandBuilder("home", 5);
+    const ref = refByPageBlockId("clx789", 2);
+
+    const cmd = builder.deleteBlock(ref);
+
+    expect(cmd).toEqual({
+      type: "delete-block",
+      pageKey: "home",
+      baseRevision: 5,
+      ref,
+    });
+  });
+
+  test("works with null baseRevision for default-backed pages", () => {
+    const builder = createPageCommandBuilder("home", null);
+    const ref = refByDefinitionKey("hero-main");
+
+    const cmd = builder.setBlockData(ref, "hero", 1, {});
+
+    expect(cmd.baseRevision).toBeNull();
+  });
+});

--- a/app/features/cms/page-commands.ts
+++ b/app/features/cms/page-commands.ts
@@ -1,0 +1,100 @@
+/**
+ * Page command types and builder.
+ *
+ * This module is intentionally kept free of server-only imports so that
+ * `createPageCommandBuilder` can be called from route components (client bundle)
+ * without violating React Router's server-only boundary.
+ */
+import type { BlockRef, PageBlockIdRef } from "./blocks/block-ref";
+import type { BlockType } from "./blocks/types";
+import type { PageKey } from "./catalog";
+import type { Revision } from "./page-status";
+
+/** A BlockRef that may be the target of delete/move commands (named fixed slots excluded). */
+export type MutableBlockRef = PageBlockIdRef;
+
+export type SetPageMetaCommand = {
+  type: "set-page-meta";
+  pageKey: PageKey;
+  baseRevision: Revision | null;
+  title: string;
+  description: string;
+};
+
+export type SetBlockDataCommand = {
+  type: "set-block-data";
+  pageKey: PageKey;
+  baseRevision: Revision | null;
+  ref: BlockRef;
+  blockType: BlockType;
+  blockVersion: number;
+  data: unknown;
+};
+
+export type MoveBlockUpCommand = {
+  type: "move-block-up";
+  pageKey: PageKey;
+  baseRevision: Revision | null;
+  ref: MutableBlockRef;
+};
+
+export type MoveBlockDownCommand = {
+  type: "move-block-down";
+  pageKey: PageKey;
+  baseRevision: Revision | null;
+  ref: MutableBlockRef;
+};
+
+export type DeleteBlockCommand = {
+  type: "delete-block";
+  pageKey: PageKey;
+  baseRevision: Revision | null;
+  ref: MutableBlockRef;
+};
+
+export type PageCommand =
+  | SetPageMetaCommand
+  | SetBlockDataCommand
+  | MoveBlockUpCommand
+  | MoveBlockDownCommand
+  | DeleteBlockCommand;
+
+export type PageCommandBuilder = {
+  setBlockData(
+    ref: BlockRef,
+    blockType: BlockType,
+    blockVersion: number,
+    data: unknown,
+  ): SetBlockDataCommand;
+  moveBlockUp(ref: MutableBlockRef): MoveBlockUpCommand;
+  moveBlockDown(ref: MutableBlockRef): MoveBlockDownCommand;
+  deleteBlock(ref: MutableBlockRef): DeleteBlockCommand;
+};
+
+export function createPageCommandBuilder(
+  pageKey: PageKey,
+  baseRevision: Revision | null,
+): PageCommandBuilder {
+  return {
+    setBlockData(ref, blockType, blockVersion, data) {
+      return {
+        type: "set-block-data",
+        pageKey,
+        baseRevision,
+        ref,
+        blockType,
+        blockVersion,
+        data,
+      };
+    },
+    moveBlockUp(ref) {
+      return { type: "move-block-up", pageKey, baseRevision, ref };
+    },
+    moveBlockDown(ref) {
+      return { type: "move-block-down", pageKey, baseRevision, ref };
+    },
+    deleteBlock(ref) {
+      return { type: "delete-block", pageKey, baseRevision, ref };
+    },
+  };
+}

--- a/app/features/cms/page-service.server.test.ts
+++ b/app/features/cms/page-service.server.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 
+import { refByDefinitionKey, refByPageBlockId } from "./blocks/block-ref";
 import type { BlockInstance } from "./catalog";
 import { createCmsPageService, type CmsPageStore } from "./page-service.server";
 import { siteCmsCatalog } from "./site-catalog";
@@ -51,11 +52,15 @@ function createMemoryPageStore(): CmsPageStore & {
         };
       }
 
+      let blockSeq = 0;
       page = {
         pageKey: nextPage.pageKey,
         title: nextPage.title,
         description: nextPage.description,
-        blocks: structuredClone(nextPage.blocks),
+        blocks: nextPage.blocks.map((b) => ({
+          ...structuredClone(b),
+          pageBlockId: `mem-block-${++blockSeq}`,
+        })),
         revision: 1,
       };
 
@@ -84,6 +89,45 @@ function createMemoryPageStore(): CmsPageStore & {
         ...page,
         title,
         description,
+        revision: page.revision + 1,
+      };
+
+      return {
+        status: "saved" as const,
+        materialization: "updated" as const,
+        persistedPage: structuredClone(page),
+      };
+    },
+    async updatePage({
+      pageKey,
+      expectedRevision,
+      title,
+      description,
+      blocks,
+    }) {
+      if (!page || page.pageKey !== pageKey) {
+        return {
+          status: "conflict" as const,
+          persistedPage: null,
+        };
+      }
+
+      if (page.revision !== expectedRevision) {
+        return {
+          status: "conflict" as const,
+          persistedPage: structuredClone(page),
+        };
+      }
+
+      let blockSeq = page.blocks.length;
+      page = {
+        ...page,
+        title,
+        description,
+        blocks: blocks.map((b) => ({
+          ...structuredClone(b),
+          pageBlockId: b.pageBlockId ?? `mem-block-${++blockSeq}`,
+        })),
         revision: page.revision + 1,
       };
 
@@ -172,9 +216,14 @@ describe("createCmsPageService", () => {
     const editorModel = await service.readEditorModel("home");
 
     expect(editorModel.status).toEqual({ kind: "persisted", revision: 1 });
-    expect(editorModel.pageSnapshot.blocks).toEqual(
-      siteCmsCatalog.readPageSnapshot("home").blocks,
-    );
+    // blocks match the default snapshot (pageBlockId is added by the store, so omit it)
+    const defaultBlocks = siteCmsCatalog.readPageSnapshot("home").blocks;
+    expect(editorModel.pageSnapshot.blocks).toHaveLength(defaultBlocks.length);
+    editorModel.pageSnapshot.blocks.forEach((block, i) => {
+      expect(block.type).toBe(defaultBlocks[i].type);
+      expect(block.data).toEqual(defaultBlocks[i].data);
+      expect(block.pageBlockId).toBeDefined();
+    });
   });
 
   test("reads the persisted home page after materialization", async () => {
@@ -368,5 +417,265 @@ describe("createCmsPageService", () => {
         revision: 2,
       });
     }
+  });
+});
+
+describe("createCmsPageService — block commands", () => {
+  /** Materialize the home page and return the service + store. */
+  async function setupPersisted() {
+    const store = createMemoryPageStore();
+    const service = createCmsPageService({
+      catalog: siteCmsCatalog,
+      pageStore: store,
+    });
+
+    const result = await service.applyPageCommand({
+      type: "set-page-meta",
+      pageKey: "home",
+      baseRevision: null,
+      title: "home title",
+      description: "home desc",
+    });
+
+    if (result.status !== "saved") throw new Error("setup: expected saved");
+
+    return { service, store, revision: result.editorModel.status.revision! };
+  }
+
+  test("set-block-data updates the hero block headline on a persisted page", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    // The hero block is at position 0 with definitionKey "hero-main"
+    const heroBlock = store.peek("home")!.blocks[0];
+    const ref = refByPageBlockId(heroBlock.pageBlockId!, 0);
+
+    const result = await service.applyPageCommand({
+      type: "set-block-data",
+      pageKey: "home",
+      baseRevision: revision,
+      ref,
+      blockType: "hero",
+      blockVersion: 1,
+      data: {
+        ...(heroBlock.data as object),
+        headline: "Updated headline",
+      },
+    });
+
+    expect(result.status).toBe("saved");
+    if (result.status !== "saved") return;
+
+    const updatedBlock = result.editorModel.pageSnapshot.blocks[0];
+    expect((updatedBlock.data as { headline: string }).headline).toBe(
+      "Updated headline",
+    );
+    expect(result.editorModel.status.revision).toBe(revision + 1);
+  });
+
+  test("set-block-data returns the current persisted editor model when block data is invalid", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    const heroBlock = store.peek("home")!.blocks[0];
+    const ref = refByPageBlockId(heroBlock.pageBlockId!, 0);
+
+    const result = await service.applyPageCommand({
+      type: "set-block-data",
+      pageKey: "home",
+      baseRevision: revision,
+      ref,
+      blockType: "hero",
+      blockVersion: 1,
+      data: { headline: 999 }, // headline must be a string
+    });
+
+    expect(result.status).toBe("conflict");
+    if (result.status !== "conflict") return;
+
+    expect(result.currentEditorModel.status).toEqual({
+      kind: "persisted",
+      revision,
+    });
+    expect(result.currentEditorModel.pageSnapshot.blocks[0]).toEqual(heroBlock);
+    expect(store.peek("home")?.revision).toBe(revision);
+  });
+
+  test("set-block-data rejects CTA href values outside the registered site targets", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    const heroBlock = store.peek("home")!.blocks[0];
+    const ref = refByPageBlockId(heroBlock.pageBlockId!, 0);
+
+    const result = await service.applyPageCommand({
+      type: "set-block-data",
+      pageKey: "home",
+      baseRevision: revision,
+      ref,
+      blockType: "hero",
+      blockVersion: 1,
+      data: {
+        ...(heroBlock.data as object),
+        actions: [{ label: "Join", href: "https://example.com" }],
+      },
+    });
+
+    expect(result.status).toBe("conflict");
+    if (result.status !== "conflict") return;
+
+    expect(result.currentEditorModel.status).toEqual({
+      kind: "persisted",
+      revision,
+    });
+    expect(
+      (
+        result.currentEditorModel.pageSnapshot.blocks[0].data as {
+          actions: { href: string }[];
+        }
+      ).actions[0].href,
+    ).toBe("/dinners");
+    expect(store.peek("home")?.revision).toBe(revision);
+  });
+
+  test("set-block-data on a default-backed page materializes the page first", async () => {
+    const store = createMemoryPageStore();
+    const service = createCmsPageService({
+      catalog: siteCmsCatalog,
+      pageStore: store,
+    });
+
+    // Hero block on the default-backed page is at position 0 with definitionKey "hero-main"
+    const ref = refByDefinitionKey("hero-main");
+    const defaultSnapshot = siteCmsCatalog.readPageSnapshot("home");
+    const defaultHeroData = defaultSnapshot.blocks[0].data as {
+      headline: string;
+      actions: { href: string; label: string }[];
+      image: { src: string };
+    };
+
+    const result = await service.applyPageCommand({
+      type: "set-block-data",
+      pageKey: "home",
+      baseRevision: null,
+      ref,
+      blockType: "hero",
+      blockVersion: 1,
+      data: { ...defaultHeroData, headline: "First materialized" },
+    });
+
+    expect(result.status).toBe("saved");
+    if (result.status !== "saved") return;
+    expect(result.materialization).toBe("created");
+    expect(result.editorModel.pageSnapshot.provenance).toBe("persisted");
+    const heroData = result.editorModel.pageSnapshot.blocks[0].data as {
+      headline: string;
+    };
+    expect(heroData.headline).toBe("First materialized");
+  });
+
+  test("move-block-up swaps a block with its predecessor", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    // Block at position 2 (image) can move to position 1 without entering the required zone
+    const blockAtTwo = store.peek("home")!.blocks[2];
+    const ref = refByPageBlockId(blockAtTwo.pageBlockId!, 2);
+
+    const result = await service.applyPageCommand({
+      type: "move-block-up",
+      pageKey: "home",
+      baseRevision: revision,
+      ref,
+    });
+
+    expect(result.status).toBe("saved");
+    if (result.status !== "saved") return;
+
+    // The block that was at index 2 is now at index 1
+    const movedBlock = result.editorModel.pageSnapshot.blocks[1];
+    expect(movedBlock.pageBlockId).toBe(blockAtTwo.pageBlockId);
+  });
+
+  test("move-block-up is rejected when the target position is in the required leading zone", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    // Block at position 1 cannot move to position 0 — hero must stay at position 0
+    const blockAtOne = store.peek("home")!.blocks[1];
+    const ref = refByPageBlockId(blockAtOne.pageBlockId!, 1);
+
+    const result = await service.applyPageCommand({
+      type: "move-block-up",
+      pageKey: "home",
+      baseRevision: revision,
+      ref,
+    });
+
+    expect(result.status).not.toBe("saved");
+  });
+
+  test("move-block-down swaps a block with its successor", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    // The last block cannot move down, so use second-to-last
+    const blocks = store.peek("home")!.blocks;
+    const secondToLast = blocks[blocks.length - 2];
+    const ref = refByPageBlockId(secondToLast.pageBlockId!, blocks.length - 2);
+
+    const result = await service.applyPageCommand({
+      type: "move-block-down",
+      pageKey: "home",
+      baseRevision: revision,
+      ref,
+    });
+
+    expect(result.status).toBe("saved");
+    if (result.status !== "saved") return;
+
+    const movedBlock =
+      result.editorModel.pageSnapshot.blocks[blocks.length - 1];
+    expect(movedBlock.pageBlockId).toBe(secondToLast.pageBlockId);
+  });
+
+  test("delete-block removes a non-required block from the page", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    const blocks = store.peek("home")!.blocks;
+    const initialCount = blocks.length;
+
+    // Position 1 is not a required leading block
+    const blockAtOne = blocks[1];
+    const ref = refByPageBlockId(blockAtOne.pageBlockId!, 1);
+
+    const result = await service.applyPageCommand({
+      type: "delete-block",
+      pageKey: "home",
+      baseRevision: revision,
+      ref,
+    });
+
+    expect(result.status).toBe("saved");
+    if (result.status !== "saved") return;
+    expect(result.editorModel.pageSnapshot.blocks).toHaveLength(
+      initialCount - 1,
+    );
+    expect(
+      result.editorModel.pageSnapshot.blocks.find(
+        (b) => b.pageBlockId === blockAtOne.pageBlockId,
+      ),
+    ).toBeUndefined();
+  });
+
+  test("delete-block is rejected for a block in a required leading slot", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    // Hero is at position 0 and is in requiredLeadingBlockTypes
+    const heroBlock = store.peek("home")!.blocks[0];
+    const ref = refByPageBlockId(heroBlock.pageBlockId!, 0);
+
+    const result = await service.applyPageCommand({
+      type: "delete-block",
+      pageKey: "home",
+      baseRevision: revision,
+      ref,
+    });
+
+    expect(result.status).not.toBe("saved");
   });
 });

--- a/app/features/cms/page-service.server.ts
+++ b/app/features/cms/page-service.server.ts
@@ -1,3 +1,4 @@
+import type { BlockRef } from "./blocks/block-ref";
 import type {
   BlockInstance,
   CmsCatalog,
@@ -6,10 +7,32 @@ import type {
   PublicProjection,
   PublicProjectionContext,
 } from "./catalog";
+import type {
+  DeleteBlockCommand,
+  MoveBlockDownCommand,
+  MoveBlockUpCommand,
+  MutableBlockRef,
+  PageCommand,
+  SetBlockDataCommand,
+  SetPageMetaCommand,
+} from "./page-commands";
 import type { PageStatus, Revision } from "./page-status";
 
 export { formatPageStatus } from "./page-status";
 export type { PageStatus, Revision } from "./page-status";
+// Re-export command types from the client-safe module so existing importers
+// of page-service.server continue to work without changes.
+export { createPageCommandBuilder } from "./page-commands";
+export type {
+  DeleteBlockCommand,
+  MoveBlockDownCommand,
+  MoveBlockUpCommand,
+  MutableBlockRef,
+  PageCommand,
+  PageCommandBuilder,
+  SetBlockDataCommand,
+  SetPageMetaCommand,
+} from "./page-commands";
 
 export type Diagnostic = {
   code:
@@ -70,14 +93,14 @@ export type CmsPageStore = {
     title: string;
     description: string;
   }): Promise<WriteSuccess | WriteConflict>;
-};
-
-export type PageCommand = {
-  type: "set-page-meta";
-  pageKey: PageKey;
-  baseRevision: Revision | null;
-  title: string;
-  description: string;
+  /** Write the full page snapshot (meta + blocks) atomically with a revision bump. */
+  updatePage(input: {
+    pageKey: PageKey;
+    expectedRevision: Revision;
+    title: string;
+    description: string;
+    blocks: readonly BlockInstance[];
+  }): Promise<WriteSuccess | WriteConflict>;
 };
 
 export type ApplyPageCommandResult =
@@ -201,6 +224,294 @@ export function createCmsPageService({
     diagnostics: [],
   });
 
+  /** Resolve a BlockRef to an index in the blocks array. Returns -1 if not found. */
+  const resolveBlockIndex = (
+    blocks: readonly BlockInstance[],
+    ref: BlockRef,
+  ): number => {
+    switch (ref.kind) {
+      case "definition-key":
+        return blocks.findIndex((b) => b.definitionKey === ref.definitionKey);
+      case "page-block-id":
+        return blocks.findIndex((b) => b.pageBlockId === ref.pageBlockId);
+    }
+  };
+
+  /**
+   * Apply a block mutation to a persisted snapshot, persist it, and return the result.
+   * Handles materialization if the page is still default-backed.
+   */
+  const applyBlockMutation = async (
+    command:
+      | SetBlockDataCommand
+      | MoveBlockUpCommand
+      | MoveBlockDownCommand
+      | DeleteBlockCommand,
+    mutate: (blocks: BlockInstance[]) => BlockInstance[] | null,
+  ): Promise<ApplyPageCommandResult> => {
+    const currentPage = await readResolvedPage(command.pageKey);
+
+    // Check concurrency
+    if (currentPage.status.kind === "default-backed") {
+      if (command.baseRevision !== null) {
+        return {
+          status: "conflict",
+          currentEditorModel: currentPage,
+          diagnostics: [],
+        };
+      }
+    } else {
+      if (
+        command.baseRevision === null ||
+        command.baseRevision !== currentPage.status.revision
+      ) {
+        return {
+          status: "conflict",
+          currentEditorModel: currentPage,
+          diagnostics: [],
+        };
+      }
+    }
+
+    const blocks = [...currentPage.pageSnapshot.blocks];
+    const mutatedBlocks = mutate(blocks);
+
+    // null signals a rule violation — return a conflict
+    if (mutatedBlocks === null) {
+      return {
+        status: "conflict",
+        currentEditorModel: currentPage,
+        diagnostics: [],
+      };
+    }
+
+    if (currentPage.status.kind === "default-backed") {
+      const writeResult = await pageStore.materializePage({
+        page: {
+          pageKey: command.pageKey,
+          title: currentPage.pageSnapshot.title,
+          description: currentPage.pageSnapshot.description,
+          blocks: mutatedBlocks,
+        },
+      });
+
+      if (writeResult.status === "conflict") {
+        const refreshed = await readResolvedPage(command.pageKey);
+        return {
+          status: "conflict",
+          currentEditorModel: refreshed,
+          diagnostics: [],
+        };
+      }
+
+      return {
+        status: "saved",
+        materialization: writeResult.materialization,
+        editorModel: resolvedPageFromPersisted(
+          command.pageKey,
+          writeResult.persistedPage,
+        ),
+      };
+    }
+
+    const writeResult = await pageStore.updatePage({
+      pageKey: command.pageKey,
+      expectedRevision: currentPage.status.revision,
+      title: currentPage.pageSnapshot.title,
+      description: currentPage.pageSnapshot.description,
+      blocks: mutatedBlocks,
+    });
+
+    if (writeResult.status === "conflict") {
+      const refreshed = await readResolvedPage(command.pageKey);
+      return {
+        status: "conflict",
+        currentEditorModel: refreshed,
+        diagnostics: [],
+      };
+    }
+
+    return {
+      status: "saved",
+      materialization: writeResult.materialization,
+      editorModel: resolvedPageFromPersisted(
+        command.pageKey,
+        writeResult.persistedPage,
+      ),
+    };
+  };
+
+  const applySetBlockData = async (
+    command: SetBlockDataCommand,
+  ): Promise<ApplyPageCommandResult> => {
+    let definition;
+    try {
+      definition = catalog.getBlockDefinition(command.blockType);
+    } catch {
+      return {
+        status: "conflict",
+        currentEditorModel: await readResolvedPage(command.pageKey),
+        diagnostics: [],
+      };
+    }
+
+    const parseResult = definition.schema.safeParse(command.data);
+    if (!parseResult.success) {
+      return {
+        status: "conflict",
+        currentEditorModel: await readResolvedPage(command.pageKey),
+        diagnostics: [],
+      };
+    }
+
+    const validatedData = parseResult.data;
+
+    return applyBlockMutation(command, (blocks) => {
+      const index = resolveBlockIndex(blocks, command.ref);
+      if (index === -1) return null;
+
+      const updated = [...blocks];
+      updated[index] = { ...updated[index], data: validatedData };
+      return updated;
+    });
+  };
+
+  const getRequiredLeadingCount = (pageKey: PageKey): number =>
+    catalog.getPageRule(pageKey).requiredLeadingBlockTypes?.length ?? 0;
+
+  const applyMoveBlockUp = (
+    command: MoveBlockUpCommand,
+  ): Promise<ApplyPageCommandResult> => {
+    return applyBlockMutation(command, (blocks) => {
+      const index = resolveBlockIndex(blocks, command.ref);
+      if (index <= 0) return null; // already first or not found
+
+      const newIndex = index - 1;
+      const requiredLeadingCount = getRequiredLeadingCount(command.pageKey);
+
+      // The block at newIndex is in the protected leading zone — cannot be displaced
+      if (newIndex < requiredLeadingCount) return null;
+
+      const updated = [...blocks];
+      [updated[newIndex], updated[index]] = [updated[index], updated[newIndex]];
+      return updated;
+    });
+  };
+
+  const applyMoveBlockDown = (
+    command: MoveBlockDownCommand,
+  ): Promise<ApplyPageCommandResult> => {
+    return applyBlockMutation(command, (blocks) => {
+      const index = resolveBlockIndex(blocks, command.ref);
+      if (index === -1 || index >= blocks.length - 1) return null;
+
+      const requiredLeadingCount = getRequiredLeadingCount(command.pageKey);
+      if (index < requiredLeadingCount) return null; // required leading block cannot move down
+
+      const updated = [...blocks];
+      [updated[index], updated[index + 1]] = [
+        updated[index + 1],
+        updated[index],
+      ];
+      return updated;
+    });
+  };
+
+  const applyDeleteBlock = (
+    command: DeleteBlockCommand,
+  ): Promise<ApplyPageCommandResult> => {
+    return applyBlockMutation(command, (blocks) => {
+      const index = resolveBlockIndex(blocks, command.ref);
+      if (index === -1) return null;
+
+      const requiredLeadingCount = getRequiredLeadingCount(command.pageKey);
+      if (index < requiredLeadingCount) return null; // fixed slot — cannot delete
+
+      const updated = [...blocks];
+      updated.splice(index, 1);
+      return updated;
+    });
+  };
+
+  const applySetPageMeta = async (
+    command: SetPageMetaCommand,
+  ): Promise<ApplyPageCommandResult> => {
+    const currentPage = await readResolvedPage(command.pageKey);
+
+    if (currentPage.status.kind === "default-backed") {
+      if (command.baseRevision !== null) {
+        return {
+          status: "conflict",
+          currentEditorModel: currentPage,
+          diagnostics: [],
+        };
+      }
+
+      const writeResult = await pageStore.materializePage({
+        page: {
+          pageKey: command.pageKey,
+          title: command.title,
+          description: command.description,
+          blocks: currentPage.pageSnapshot.blocks,
+        },
+      });
+
+      if (writeResult.status === "conflict") {
+        const refreshed = await readResolvedPage(command.pageKey);
+        return {
+          status: "conflict",
+          currentEditorModel: refreshed,
+          diagnostics: [],
+        };
+      }
+
+      return {
+        status: "saved",
+        materialization: writeResult.materialization,
+        editorModel: resolvedPageFromPersisted(
+          command.pageKey,
+          writeResult.persistedPage,
+        ),
+      };
+    }
+
+    if (
+      command.baseRevision === null ||
+      command.baseRevision !== currentPage.status.revision
+    ) {
+      return {
+        status: "conflict",
+        currentEditorModel: currentPage,
+        diagnostics: [],
+      };
+    }
+
+    const writeResult = await pageStore.updatePageMeta({
+      pageKey: command.pageKey,
+      expectedRevision: command.baseRevision,
+      title: command.title,
+      description: command.description,
+    });
+
+    if (writeResult.status === "conflict") {
+      const refreshed = await readResolvedPage(command.pageKey);
+      return {
+        status: "conflict",
+        currentEditorModel: refreshed,
+        diagnostics: [],
+      };
+    }
+
+    return {
+      status: "saved",
+      materialization: writeResult.materialization,
+      editorModel: resolvedPageFromPersisted(
+        command.pageKey,
+        writeResult.persistedPage,
+      ),
+    };
+  };
+
   return {
     async listEditablePages() {
       return Promise.all(
@@ -229,80 +540,18 @@ export function createCmsPageService({
       return readResolvedPage(pageKey);
     },
     async applyPageCommand(command) {
-      const currentPage = await readResolvedPage(command.pageKey);
-
-      if (currentPage.status.kind === "default-backed") {
-        if (command.baseRevision !== null) {
-          return {
-            status: "conflict",
-            currentEditorModel: currentPage,
-            diagnostics: [],
-          };
-        }
-
-        const writeResult = await pageStore.materializePage({
-          page: {
-            pageKey: command.pageKey,
-            title: command.title,
-            description: command.description,
-            blocks: currentPage.pageSnapshot.blocks,
-          },
-        });
-
-        if (writeResult.status === "conflict") {
-          const refreshed = await readResolvedPage(command.pageKey);
-          return {
-            status: "conflict",
-            currentEditorModel: refreshed,
-            diagnostics: [],
-          };
-        }
-
-        return {
-          status: "saved",
-          materialization: writeResult.materialization,
-          editorModel: resolvedPageFromPersisted(
-            command.pageKey,
-            writeResult.persistedPage,
-          ),
-        };
+      switch (command.type) {
+        case "set-page-meta":
+          return applySetPageMeta(command);
+        case "set-block-data":
+          return applySetBlockData(command);
+        case "move-block-up":
+          return applyMoveBlockUp(command);
+        case "move-block-down":
+          return applyMoveBlockDown(command);
+        case "delete-block":
+          return applyDeleteBlock(command);
       }
-
-      if (
-        command.baseRevision === null ||
-        command.baseRevision !== currentPage.status.revision
-      ) {
-        return {
-          status: "conflict",
-          currentEditorModel: currentPage,
-          diagnostics: [],
-        };
-      }
-
-      const writeResult = await pageStore.updatePageMeta({
-        pageKey: command.pageKey,
-        expectedRevision: command.baseRevision,
-        title: command.title,
-        description: command.description,
-      });
-
-      if (writeResult.status === "conflict") {
-        const refreshed = await readResolvedPage(command.pageKey);
-        return {
-          status: "conflict",
-          currentEditorModel: refreshed,
-          diagnostics: [],
-        };
-      }
-
-      return {
-        status: "saved",
-        materialization: writeResult.materialization,
-        editorModel: resolvedPageFromPersisted(
-          command.pageKey,
-          writeResult.persistedPage,
-        ),
-      };
     },
   };
 }

--- a/app/features/cms/page-store.server.ts
+++ b/app/features/cms/page-store.server.ts
@@ -70,6 +70,89 @@ export function createPrismaCmsPageStore({
         throw error;
       }
     },
+    async updatePage({
+      pageKey,
+      expectedRevision,
+      title,
+      description,
+      blocks,
+    }) {
+      return prisma.$transaction(async (tx) => {
+        const existingPage = await tx.page.findUnique({
+          where: { pageKey },
+          select: { id: true, revision: true },
+        });
+
+        if (!existingPage) {
+          return { status: "conflict" as const, persistedPage: null };
+        }
+
+        if (existingPage.revision !== expectedRevision) {
+          return {
+            status: "conflict" as const,
+            persistedPage: await requirePersistedPage(tx, pageKey),
+          };
+        }
+
+        await tx.page.update({
+          where: { id: existingPage.id },
+          data: { title, description, revision: { increment: 1 } },
+        });
+
+        // Upsert blocks: preserve existing row IDs where pageBlockId matches,
+        // delete removed blocks, insert new ones.
+        const existingBlocks = await tx.pageBlock.findMany({
+          where: { pageId: existingPage.id },
+          select: { id: true },
+        });
+        const existingIds = new Set(existingBlocks.map((b) => b.id));
+        const incomingIds = new Set(
+          blocks
+            .map((b) => b.pageBlockId)
+            .filter((id): id is string => id !== undefined),
+        );
+
+        // Delete blocks that are no longer present
+        const toDelete = [...existingIds].filter((id) => !incomingIds.has(id));
+        if (toDelete.length > 0) {
+          await tx.pageBlock.deleteMany({ where: { id: { in: toDelete } } });
+        }
+
+        // Upsert each block in the new order
+        for (let position = 0; position < blocks.length; position++) {
+          const block = blocks[position];
+          if (block.pageBlockId && existingIds.has(block.pageBlockId)) {
+            await tx.pageBlock.update({
+              where: { id: block.pageBlockId },
+              data: {
+                definitionKey: block.definitionKey ?? null,
+                type: block.type,
+                version: block.version,
+                position,
+                data: JSON.stringify(block.data),
+              },
+            });
+          } else {
+            await tx.pageBlock.create({
+              data: {
+                pageId: existingPage.id,
+                definitionKey: block.definitionKey ?? null,
+                type: block.type,
+                version: block.version,
+                position,
+                data: JSON.stringify(block.data),
+              },
+            });
+          }
+        }
+
+        return {
+          status: "saved" as const,
+          materialization: "updated" as const,
+          persistedPage: await requirePersistedPage(tx, pageKey),
+        };
+      });
+    },
     async updatePageMeta({ pageKey, expectedRevision, title, description }) {
       return prisma.$transaction(async (tx) => {
         const existingPage = await tx.page.findUnique({
@@ -160,6 +243,7 @@ function serializeBlocks(pageId: string, blocks: readonly BlockInstance[]) {
 }
 
 function deserializeBlock(block: {
+  id: string;
   definitionKey: string | null;
   type: string;
   version: number;
@@ -167,6 +251,7 @@ function deserializeBlock(block: {
 }): BlockInstance {
   return {
     ...(block.definitionKey ? { definitionKey: block.definitionKey } : {}),
+    pageBlockId: block.id,
     type: block.type as BlockInstance["type"],
     version: block.version as BlockInstance["version"],
     data: JSON.parse(block.data),

--- a/app/features/cms/site-link-targets.ts
+++ b/app/features/cms/site-link-targets.ts
@@ -1,0 +1,7 @@
+import { createLinkTargetRegistry } from "./link-targets";
+
+export const siteLinkTargetRegistry = createLinkTargetRegistry([
+  { key: "home", label: "Home", href: "/" },
+  { key: "dinners", label: "Dinners", href: "/dinners" },
+  { key: "join", label: "Join", href: "/join" },
+]);

--- a/app/routes/admin.pages.$pageKey.tsx
+++ b/app/routes/admin.pages.$pageKey.tsx
@@ -14,10 +14,33 @@ import type { Route } from "./+types/admin.pages.$pageKey";
 
 import { Field, TextareaField } from "~/components/forms";
 import { Button } from "~/components/ui/button";
+import type { BlockRef } from "~/features/cms/blocks/block-ref";
+import {
+  refByDefinitionKey,
+  refByPageBlockId,
+} from "~/features/cms/blocks/block-ref";
+import {
+  applyHeroBlockEditorValue,
+  createHeroBlockEditorFormSchema,
+} from "~/features/cms/blocks/hero/editor-schema";
+import type { BlockType } from "~/features/cms/blocks/types";
+import type {
+  BlockEditorCapabilities,
+  BlockEditorContext,
+} from "~/features/cms/catalog";
+import type { BlockInstance } from "~/features/cms/catalog";
+import {
+  createPageCommandBuilder,
+  type MutableBlockRef,
+} from "~/features/cms/page-commands";
 import type { PageCommand } from "~/features/cms/page-service.server";
 import { formatPageStatus } from "~/features/cms/page-status";
+import { siteCmsCatalog } from "~/features/cms/site-catalog";
+import { siteLinkTargetRegistry } from "~/features/cms/site-link-targets";
 import { siteCmsPageService } from "~/features/cms/site-page-service.server";
 import { requireUserWithRole } from "~/utils/session.server";
+
+// ─── Schemas ──────────────────────────────────────────────────────────────────
 
 const PageMetaSchema = z.object({
   title: z
@@ -36,9 +59,259 @@ const PageMetaSchema = z.object({
     .pipe(z.number().int().nonnegative().nullable()),
 });
 
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+function requireKnownPageKey(pageKey: string | undefined) {
+  invariant(typeof pageKey === "string", "Parameter pageKey is missing");
+
+  if (!siteCmsPageService.isKnownPageKey(pageKey)) {
+    throw new Response("Not found", { status: 404 });
+  }
+
+  return pageKey;
+}
+
+function parseBlockRef(raw: FormDataEntryValue | null): BlockRef | null {
+  if (typeof raw !== "string") return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "kind" in parsed &&
+      typeof (parsed as { kind: unknown }).kind === "string"
+    ) {
+      return parsed as BlockRef;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function parseBaseRevision(raw: FormDataEntryValue | null): number | null {
+  if (typeof raw !== "string" || raw === "") return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
+// ─── Loader ───────────────────────────────────────────────────────────────────
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  await requireUserWithRole(request, ["moderator", "admin"]);
+
+  const pageKey = requireKnownPageKey(params.pageKey);
+
+  return {
+    editorModel: await siteCmsPageService.readEditorModel(pageKey),
+    linkTargetRegistry: siteLinkTargetRegistry,
+  };
+}
+
+// ─── Action ───────────────────────────────────────────────────────────────────
+
+export async function action({ request, params }: Route.ActionArgs) {
+  await requireUserWithRole(request, ["moderator", "admin"]);
+
+  const pageKey = requireKnownPageKey(params.pageKey);
+  const formData = await request.formData();
+  const intent = formData.get("intent");
+
+  // Default (no intent field) → set-page-meta via Conform
+  if (!intent || intent === "set-page-meta") {
+    const submission = parseWithZod(formData, { schema: PageMetaSchema });
+
+    if (submission.status !== "success" || !submission.value) {
+      return submission.reply();
+    }
+
+    const command: PageCommand = {
+      type: "set-page-meta",
+      pageKey,
+      baseRevision: submission.value.revision,
+      title: submission.value.title,
+      description: submission.value.description,
+    };
+
+    const result = await siteCmsPageService.applyPageCommand(command);
+
+    if (result.status === "conflict") {
+      return {
+        status: "conflict" as const,
+        conflictMessage:
+          "This page was changed by someone else. The editor has been refreshed with the current values - please review and save again.",
+        editorModel: result.currentEditorModel,
+      };
+    }
+
+    return redirect(`/admin/pages/${pageKey}`);
+  }
+
+  // Block commands — all share blockRef + baseRevision
+  const blockRef = parseBlockRef(formData.get("blockRef"));
+  const baseRevision = parseBaseRevision(formData.get("baseRevision"));
+
+  if (!blockRef) {
+    throw new Response("Missing or invalid blockRef", { status: 400 });
+  }
+
+  const commandBuilder = createPageCommandBuilder(pageKey, baseRevision);
+
+  if (intent === "set-block-data") {
+    const blockType = formData.get("blockType");
+    const blockVersionRaw = formData.get("blockVersion");
+
+    if (typeof blockType !== "string" || typeof blockVersionRaw !== "string") {
+      throw new Response("Missing blockType or blockVersion", { status: 400 });
+    }
+
+    const blockVersion = Number(blockVersionRaw);
+    const serializedBlockRef = JSON.stringify(blockRef);
+
+    if (blockType !== "hero" || blockVersion !== 1) {
+      throw new Response("Unsupported block editor payload", { status: 400 });
+    }
+
+    const heroSchema = createHeroBlockEditorFormSchema(siteLinkTargetRegistry);
+    const heroSubmission = parseWithZod(formData, {
+      schema: heroSchema,
+    });
+
+    if (heroSubmission.status !== "success" || !heroSubmission.value) {
+      return {
+        status: "block-validation-error" as const,
+        blockRef: serializedBlockRef,
+        editorModel: await siteCmsPageService.readEditorModel(pageKey),
+        lastResult: heroSubmission.reply(),
+      };
+    }
+
+    const currentEditorModel =
+      await siteCmsPageService.readEditorModel(pageKey);
+    const currentBlocks = currentEditorModel.pageSnapshot.blocks;
+    const currentBlock = resolveBlock(currentBlocks, blockRef);
+    if (!currentBlock || currentBlock.type !== "hero") {
+      return {
+        status: "block-conflict" as const,
+        blockRef: serializedBlockRef,
+        conflictMessage:
+          "Block could not be saved — the editor has been refreshed with the current block.",
+        editorModel: currentEditorModel,
+      };
+    }
+
+    const command = commandBuilder.setBlockData(
+      blockRef,
+      blockType as BlockType,
+      blockVersion,
+      applyHeroBlockEditorValue(
+        currentBlock.data as Parameters<typeof applyHeroBlockEditorValue>[0],
+        heroSubmission.value,
+      ),
+    );
+
+    const result = await siteCmsPageService.applyPageCommand(command);
+
+    if (result.status === "conflict") {
+      return {
+        status: "block-conflict" as const,
+        blockRef: serializedBlockRef,
+        conflictMessage: "Block could not be saved — please refresh and retry.",
+        editorModel: result.currentEditorModel,
+      };
+    }
+
+    return redirect(`/admin/pages/${pageKey}`);
+  }
+
+  if (intent === "move-block-up" || intent === "move-block-down") {
+    if (blockRef.kind !== "page-block-id") {
+      throw new Response("move commands require a page-block-id ref", {
+        status: 400,
+      });
+    }
+
+    const mutableRef: MutableBlockRef = blockRef;
+    const command =
+      intent === "move-block-up"
+        ? commandBuilder.moveBlockUp(mutableRef)
+        : commandBuilder.moveBlockDown(mutableRef);
+
+    const result = await siteCmsPageService.applyPageCommand(command);
+
+    if (result.status === "conflict") {
+      return {
+        status: "conflict" as const,
+        conflictMessage:
+          "Move could not be applied — the page may have changed.",
+        editorModel: result.currentEditorModel,
+      };
+    }
+
+    return redirect(`/admin/pages/${pageKey}`);
+  }
+
+  if (intent === "delete-block") {
+    if (blockRef.kind !== "page-block-id") {
+      throw new Response("delete command requires a page-block-id ref", {
+        status: 400,
+      });
+    }
+
+    const mutableRef: MutableBlockRef = blockRef;
+    const command = commandBuilder.deleteBlock(mutableRef);
+    const result = await siteCmsPageService.applyPageCommand(command);
+
+    if (result.status === "conflict") {
+      return {
+        status: "conflict" as const,
+        conflictMessage:
+          "Delete could not be applied — the block may be in a fixed slot.",
+        editorModel: result.currentEditorModel,
+      };
+    }
+
+    return redirect(`/admin/pages/${pageKey}`);
+  }
+
+  throw new Response(`Unknown intent: ${String(intent)}`, { status: 400 });
+}
+
+function resolveBlock(
+  blocks: BlockInstance[],
+  ref: BlockRef,
+): BlockInstance | undefined {
+  switch (ref.kind) {
+    case "definition-key":
+      return blocks.find((b) => b.definitionKey === ref.definitionKey);
+    case "page-block-id":
+      return blocks.find((b) => b.pageBlockId === ref.pageBlockId);
+  }
+}
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+export function meta({ data, params }: Route.MetaArgs) {
+  if (!data) {
+    return [{ title: `Admin - Pages - ${params.pageKey ?? "Page"}` }];
+  }
+
+  return [{ title: `Admin - Pages - ${data.editorModel.pageKey}` }];
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
 type PageEditorLoaderData = Awaited<ReturnType<typeof loader>>;
 type PageEditorActionData = Awaited<ReturnType<typeof action>>;
 type ConflictActionData = Extract<PageEditorActionData, { status: "conflict" }>;
+type BlockConflictActionData = Extract<
+  PageEditorActionData,
+  { status: "block-conflict" }
+>;
+type BlockValidationActionData = Extract<
+  PageEditorActionData,
+  { status: "block-validation-error" }
+>;
 type PageMetaFormShape = {
   title: string;
   description: string;
@@ -50,92 +323,136 @@ type PageMetaFormValue = {
   revision: number | null;
 };
 
-export async function loader({ request, params }: Route.LoaderArgs) {
-  await requireUserWithRole(request, ["moderator", "admin"]);
-
-  const pageKey = requireKnownPageKey(params.pageKey);
-
-  return {
-    editorModel: await siteCmsPageService.readEditorModel(pageKey),
-  };
+function hasActionStatus<TStatus extends string>(
+  data: unknown,
+  status: TStatus,
+): data is { status: TStatus } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "status" in data &&
+    (data as { status: unknown }).status === status
+  );
 }
 
-export async function action({ request, params }: Route.ActionArgs) {
-  await requireUserWithRole(request, ["moderator", "admin"]);
-
-  const pageKey = requireKnownPageKey(params.pageKey);
-  const formData = await request.formData();
-  const submission = parseWithZod(formData, { schema: PageMetaSchema });
-
-  if (submission.status !== "success" || !submission.value) {
-    return submission.reply();
-  }
-
-  const baseRevision = submission.value.revision;
-  const setPageMetaCommand: PageCommand = {
-    type: "set-page-meta",
-    pageKey,
-    baseRevision,
-    title: submission.value.title,
-    description: submission.value.description,
-  };
-
-  const result = await siteCmsPageService.applyPageCommand(setPageMetaCommand);
-
-  if (result.status === "conflict") {
-    return {
-      status: "conflict" as const,
-      conflictMessage:
-        "This page was changed by someone else. The editor has been refreshed with the current values - please review and save again.",
-      editorModel: result.currentEditorModel,
-    };
-  }
-
-  return redirect(`/admin/pages/${pageKey}`);
-}
-
-export function meta({ data, params }: Route.MetaArgs) {
-  if (!data) {
-    return [{ title: `Admin - Pages - ${params.pageKey ?? "Page"}` }];
-  }
-
-  return [{ title: `Admin - Pages - ${data.editorModel.pageKey}` }];
-}
+// ─── Route component ──────────────────────────────────────────────────────────
 
 export default function AdminPageEditorRoute() {
-  const { editorModel } = useLoaderData<typeof loader>();
+  const { editorModel, linkTargetRegistry } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
-  const conflictAction =
-    actionData &&
-    typeof actionData === "object" &&
-    "status" in actionData &&
-    actionData.status === "conflict"
-      ? actionData
-      : null;
-  const displayEditorModel = conflictAction?.editorModel ?? editorModel;
-  const lastResult = conflictAction
+  const conflictAction = hasActionStatus(actionData, "conflict")
+    ? (actionData as ConflictActionData)
+    : null;
+  const blockConflictAction = hasActionStatus(actionData, "block-conflict")
+    ? (actionData as BlockConflictActionData)
+    : null;
+  const blockValidationAction = hasActionStatus(
+    actionData,
+    "block-validation-error",
+  )
+    ? (actionData as BlockValidationActionData)
+    : null;
+  const displayEditorModel =
+    conflictAction?.editorModel ??
+    blockConflictAction?.editorModel ??
+    blockValidationAction?.editorModel ??
+    editorModel;
+  const hasCustomActionData =
+    conflictAction || blockConflictAction || blockValidationAction;
+  const lastResult = hasCustomActionData
     ? null
     : ((actionData as SubmissionResult<string[]> | undefined) ?? null);
   const conflictMessage = conflictAction?.conflictMessage ?? null;
 
+  const revision = displayEditorModel.status.revision;
+  const commandBuilder = createPageCommandBuilder(
+    displayEditorModel.pageKey,
+    revision,
+  );
+  const pageRule = siteCmsCatalog.getPageRule(displayEditorModel.pageKey);
+  const requiredLeadingCount = pageRule.requiredLeadingBlockTypes?.length ?? 0;
+  const blocks = displayEditorModel.pageSnapshot.blocks;
+
   return (
-    <PageEditorForm
-      key={`${displayEditorModel.pageKey}-${displayEditorModel.status.revision ?? "default"}`}
-      editorModel={displayEditorModel}
-      lastResult={lastResult}
-      conflictMessage={conflictMessage}
-    />
+    <main className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-4xl">Edit {displayEditorModel.pageKey}</h1>
+        <p>{formatPageStatus(displayEditorModel.status)}</p>
+        {displayEditorModel.diagnostics.map((diagnostic) => (
+          <p
+            key={`${diagnostic.code}-${diagnostic.message}`}
+            className="text-destructive text-sm"
+          >
+            {diagnostic.message}
+          </p>
+        ))}
+      </div>
+
+      {conflictMessage ? (
+        <p className="text-destructive text-sm">{conflictMessage}</p>
+      ) : null}
+
+      <PageMetaForm
+        key={`${displayEditorModel.pageKey}-${displayEditorModel.status.revision ?? "default"}`}
+        editorModel={displayEditorModel}
+        lastResult={lastResult}
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-2xl">Blocks</h2>
+        {blocks.map((block, index) => {
+          const definition = siteCmsCatalog.getBlockDefinition(block.type);
+
+          if (!definition.editor) return null;
+
+          const blockRef: BlockRef = block.pageBlockId
+            ? refByPageBlockId(block.pageBlockId, index)
+            : refByDefinitionKey(block.definitionKey ?? `block-${index}`);
+          const serializedBlockRef = JSON.stringify(blockRef);
+
+          const capabilities: BlockEditorCapabilities = {
+            canMoveUp: index > requiredLeadingCount && index > 0,
+            canMoveDown:
+              index >= requiredLeadingCount && index < blocks.length - 1,
+            canDelete: index >= requiredLeadingCount,
+          };
+
+          const ctx: BlockEditorContext = {
+            data: block.data,
+            blockRef,
+            commandBuilder,
+            linkTargetRegistry,
+            capabilities,
+            formState:
+              definition.type === "hero" &&
+              (blockValidationAction?.blockRef === serializedBlockRef ||
+                blockConflictAction?.blockRef === serializedBlockRef)
+                ? {
+                    lastResult: blockValidationAction?.lastResult ?? null,
+                    errorMessage: blockConflictAction?.conflictMessage ?? null,
+                  }
+                : undefined,
+          };
+
+          return (
+            <div key={block.pageBlockId ?? `${block.type}-${index}`}>
+              {definition.editor(ctx)}
+            </div>
+          );
+        })}
+      </section>
+    </main>
   );
 }
 
-function PageEditorForm({
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function PageMetaForm({
   editorModel,
   lastResult,
-  conflictMessage,
 }: {
   editorModel: PageEditorLoaderData["editorModel"];
   lastResult: SubmissionResult<string[]> | null;
-  conflictMessage: string | null;
 }) {
   const formVersionKey = `${editorModel.pageKey}-${editorModel.status.revision ?? "default"}`;
 
@@ -158,67 +475,38 @@ function PageEditorForm({
   });
 
   return (
-    <main className="flex flex-col gap-6">
-      <div className="flex flex-col gap-2">
-        <h1 className="text-4xl">Edit {editorModel.pageKey}</h1>
-        <p>{formatPageStatus(editorModel.status)}</p>
-        {editorModel.diagnostics.map((diagnostic) => (
-          <p
-            key={`${diagnostic.code}-${diagnostic.message}`}
-            className="text-destructive text-sm"
-          >
-            {diagnostic.message}
-          </p>
-        ))}
-      </div>
+    <Form
+      key={formVersionKey}
+      method="POST"
+      className="flex flex-col gap-6"
+      {...getFormProps(form)}
+    >
+      <input {...getInputProps(fields.revision, { type: "hidden" })} />
 
-      <Form
-        key={formVersionKey}
-        method="POST"
-        className="flex flex-col gap-6"
-        {...getFormProps(form)}
-      >
-        <input {...getInputProps(fields.revision, { type: "hidden" })} />
+      {form.errors?.length ? (
+        <p className="text-destructive text-sm">{form.errors.join(" ")}</p>
+      ) : null}
 
-        {conflictMessage ? (
-          <p className="text-destructive text-sm">{conflictMessage}</p>
-        ) : null}
+      <Field
+        key={`${formVersionKey}-title`}
+        labelProps={{ children: "Title" }}
+        inputProps={{ ...getInputProps(fields.title, { type: "text" }) }}
+        errors={fields.title.errors}
+        className="flex flex-col gap-2"
+      />
 
-        {form.errors?.length ? (
-          <p className="text-destructive text-sm">{form.errors.join(" ")}</p>
-        ) : null}
+      <TextareaField
+        key={`${formVersionKey}-description`}
+        labelProps={{ children: "Description" }}
+        textareaProps={{
+          ...getTextareaProps(fields.description),
+          rows: 2,
+        }}
+        errors={fields.description.errors}
+        className="flex flex-col gap-2"
+      />
 
-        <Field
-          key={`${formVersionKey}-title`}
-          labelProps={{ children: "Title" }}
-          inputProps={{ ...getInputProps(fields.title, { type: "text" }) }}
-          errors={fields.title.errors}
-          className="flex flex-col gap-2"
-        />
-
-        <TextareaField
-          key={`${formVersionKey}-description`}
-          labelProps={{ children: "Description" }}
-          textareaProps={{
-            ...getTextareaProps(fields.description),
-            rows: 2,
-          }}
-          errors={fields.description.errors}
-          className="flex flex-col gap-2"
-        />
-
-        <Button type="submit">Save Page</Button>
-      </Form>
-    </main>
+      <Button type="submit">Save Page</Button>
+    </Form>
   );
-}
-
-function requireKnownPageKey(pageKey: string | undefined) {
-  invariant(typeof pageKey === "string", "Parameter pageKey is missing");
-
-  if (!siteCmsPageService.isKnownPageKey(pageKey)) {
-    throw new Response("Not found", { status: 404 });
-  }
-
-  return pageKey;
 }

--- a/cypress/e2e/admin-hero-editor.cy.ts
+++ b/cypress/e2e/admin-hero-editor.cy.ts
@@ -1,0 +1,124 @@
+import { runUploadDbCommand } from "../support/upload-test-utils";
+
+describe("admin cms hero block editor", () => {
+  beforeEach(() => {
+    cy.loginAsRole("moderator");
+    // Start fresh — default-backed page each time
+    runUploadDbCommand("delete-page", { pageKey: "home" });
+  });
+
+  afterEach(() => {
+    runUploadDbCommand("delete-page", { pageKey: "home" });
+  });
+
+  it("edits hero headline, CTA label, and CTA destination; admin and public pages reflect the saved changes", () => {
+    cy.visitAndCheck("/admin/pages/home");
+
+    cy.findByRole("button", { name: /save page/i }).click();
+    cy.findByText(/persisted page/i).should("be.visible");
+
+    cy.findByLabelText(/^headline$/i).should("be.visible");
+
+    cy.findByLabelText(/^headline$/i)
+      .clear()
+      .type("New hero headline from CMS");
+    cy.findByLabelText(/^cta label$/i)
+      .clear()
+      .type("Browse dinners");
+    cy.findByLabelText(/^cta destination$/i).select("Dinners");
+
+    cy.findByRole("button", { name: /save block/i }).click();
+    cy.findByText(/persisted page/i).should("be.visible");
+
+    cy.visitAndCheck("/admin/pages/home");
+    cy.findByLabelText(/^headline$/i).should(
+      "have.value",
+      "New hero headline from CMS",
+    );
+    cy.findByLabelText(/^cta label$/i).should("have.value", "Browse dinners");
+    cy.findByLabelText(/^cta destination$/i).should("have.value", "/dinners");
+
+    cy.visitAndCheck("/");
+    cy.contains("New hero headline from CMS").should("be.visible");
+    cy.findByRole("link", { name: /browse dinners/i }).should(
+      "have.attr",
+      "href",
+      "/dinners",
+    );
+  });
+
+  it("shows block validation errors without dropping the entered hero form state", () => {
+    cy.visitAndCheck("/admin/pages/home");
+    cy.findByRole("button", { name: /save page/i }).click();
+
+    cy.findByLabelText(/^headline$/i)
+      .clear()
+      .type("Edited headline with invalid CTA");
+    cy.findByLabelText(/^cta label$/i).clear();
+
+    cy.findByRole("button", { name: /save block/i }).click();
+
+    cy.findByText(/cta label is required/i).should("be.visible");
+    cy.findByLabelText(/^headline$/i).should(
+      "have.value",
+      "Edited headline with invalid CTA",
+    );
+    cy.findByLabelText(/^cta label$/i).should("have.value", "");
+    cy.findByText(/revision 1/i).should("be.visible");
+  });
+
+  it("rejects forged block saves that post an external CTA href", () => {
+    cy.visitAndCheck("/admin/pages/home");
+    cy.findByRole("button", { name: /save page/i }).click();
+
+    cy.request({
+      method: "POST",
+      url: "/admin/pages/home",
+      form: true,
+      failOnStatusCode: false,
+      body: {
+        intent: "set-block-data",
+        blockRef: JSON.stringify({
+          kind: "definition-key",
+          definitionKey: "hero-main",
+        }),
+        blockType: "hero",
+        blockVersion: "1",
+        baseRevision: "1",
+        eyebrow: "our next event is on may 9th",
+        headline: "moku pona",
+        description:
+          "A dinner society in Zurich, bringing people together through shared meals, stories, and the joy of discovery.",
+        "actions[0].label": "Join a dinner",
+        "actions[0].href": "https://example.com",
+      },
+    }).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(String(response.body)).to.include(
+        "CTA destination must be one of the registered site links",
+      );
+    });
+
+    cy.visitAndCheck("/admin/pages/home");
+    cy.findByLabelText(/^cta destination$/i).should("have.value", "/dinners");
+
+    cy.visitAndCheck("/");
+    cy.findByRole("link", { name: /join a dinner/i }).should(
+      "have.attr",
+      "href",
+      "/dinners",
+    );
+  });
+
+  it("hero block editor shows read-only image and no move/delete controls for the fixed hero slot", () => {
+    cy.visitAndCheck("/admin/pages/home");
+
+    // The image src should appear as a read-only reference, not an editable input
+    cy.findByText(/hero-image\.jpg/i).should("be.visible");
+    cy.get('input[value="/hero-image.jpg"]').should("not.exist");
+
+    // Move-up and delete buttons should not exist for the fixed hero block
+    cy.findByRole("button", { name: /move up/i }).should("not.exist");
+    cy.findByRole("button", { name: /delete block/i }).should("not.exist");
+  });
+});


### PR DESCRIPTION
Closes #364

## Summary

- add the first generic CMS block-mutation flow with typed block refs, page commands, and page-service support for hero block edits plus fixed-slot enforcement
- add a Conform-backed hero editor on `/admin/pages/home` with inline CTA label/destination editing, preserved validation state, and safe structural controls
- enforce centralized CTA target validation on the server and add unit plus Cypress coverage for persistence, rejection, and end-to-end public-page reflection

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run test -- --run app/features/cms/blocks/hero/editor.test.tsx app/features/cms/page-service.server.test.ts`
- `env -u ELECTRON_RUN_AS_NODE npx cross-env PORT=8811 start-server-and-test start:mocks http://localhost:8811 "npx cypress run --spec cypress/e2e/admin-dinner-uploads.cy.ts,cypress/e2e/admin-hero-editor.cy.ts"`
