### PR TITLE
feat(cms): hero image replacement and lifecycle cleanup

### DIFF
--- a/app/components/dinner-card.tsx
+++ b/app/components/dinner-card.tsx
@@ -2,9 +2,9 @@ import { Link } from "react-router";
 
 import type { Event } from "#prisma/generated/client";
 
+import { OptimizedImage } from "./optimized-image";
 import { Button } from "./ui/button";
 
-import { OptimizedImage } from "~/routes/file.$fileId";
 import { dateFormatBuilder } from "~/utils/misc";
 
 export function DinnerCard({

--- a/app/components/dinner-view.tsx
+++ b/app/components/dinner-view.tsx
@@ -8,6 +8,7 @@ import clsx from "clsx";
 import type { ReactNode } from "react";
 
 import { AutoLink } from "./auto-link";
+import { OptimizedImage } from "./optimized-image";
 import {
   Accordion,
   AccordionContent,
@@ -17,7 +18,6 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 
 import type { loader } from "~/routes/admin.dinners.$dinnerId";
-import { OptimizedImage } from "~/routes/file.$fileId";
 import { dateFormatBuilder } from "~/utils/misc";
 
 export interface DinnerViewProps {

--- a/app/components/optimized-image.test.tsx
+++ b/app/components/optimized-image.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { OptimizedImage } from "./optimized-image";
+
+describe("OptimizedImage", () => {
+  test("does not generate srcSet candidates larger than the requested width", () => {
+    const html = renderToStaticMarkup(
+      <OptimizedImage imageId="img_123" width={640} height={480} alt="" />,
+    );
+
+    expect(html).toContain("432w");
+    expect(html).toContain("640w");
+    expect(html).not.toContain("864w");
+    expect(html).not.toContain("1080w");
+  });
+
+  test("forwards the sizes attribute to the underlying image", () => {
+    const html = renderToStaticMarkup(
+      <OptimizedImage
+        imageId="img_123"
+        width={640}
+        height={480}
+        alt=""
+        sizes="(min-width: 1024px) 640px, 100vw"
+      />,
+    );
+
+    expect(html).toContain('sizes="(min-width: 1024px) 640px, 100vw"');
+  });
+});

--- a/app/components/optimized-image.tsx
+++ b/app/components/optimized-image.tsx
@@ -17,6 +17,8 @@ type OptimizedImageProps = Omit<
 > &
   ImageInputProps;
 
+const RESPONSIVE_BREAKPOINTS = [432, 648, 864, 1080];
+
 export function OptimizedImage({
   imageId,
   width,
@@ -24,9 +26,11 @@ export function OptimizedImage({
   fit = "cover",
   ...props
 }: OptimizedImageProps) {
-  const breakPoints = [432, 648, 864, 1080];
   const imageUrl = getImageUrl(imageId);
   const aspect = width / height;
+  const responsiveWidths = [...new Set([...RESPONSIVE_BREAKPOINTS, width])]
+    .filter((candidateWidth) => candidateWidth <= width)
+    .sort((left, right) => left - right);
 
   const searchParams = new URLSearchParams({
     w: `${width}`,
@@ -34,7 +38,7 @@ export function OptimizedImage({
     fit,
   });
 
-  const srcSetUrls = breakPoints.map((w) => {
+  const srcSetUrls = responsiveWidths.map((w) => {
     const h = w / aspect;
     const searchParams = new URLSearchParams({
       w: `${w}`,

--- a/app/components/optimized-image.tsx
+++ b/app/components/optimized-image.tsx
@@ -1,0 +1,59 @@
+import type { ComponentProps } from "react";
+
+import { getImageUrl } from "~/utils/misc";
+
+type OptimizedImageFit = "cover" | "contain" | "fill";
+
+type ImageInputProps = {
+  imageId: string;
+  width: number;
+  height: number;
+  fit?: OptimizedImageFit;
+};
+
+type OptimizedImageProps = Omit<
+  ComponentProps<"img">,
+  "width" | "height" | "src"
+> &
+  ImageInputProps;
+
+export function OptimizedImage({
+  imageId,
+  width,
+  height,
+  fit = "cover",
+  ...props
+}: OptimizedImageProps) {
+  const breakPoints = [432, 648, 864, 1080];
+  const imageUrl = getImageUrl(imageId);
+  const aspect = width / height;
+
+  const searchParams = new URLSearchParams({
+    w: `${width}`,
+    h: `${height}`,
+    fit,
+  });
+
+  const srcSetUrls = breakPoints.map((w) => {
+    const h = w / aspect;
+    const searchParams = new URLSearchParams({
+      w: `${w}`,
+      h: `${h}`,
+      fit,
+    });
+
+    return `${imageUrl + "?" + searchParams.toString()} ${w}w`;
+  });
+
+  return (
+    <picture>
+      <img
+        srcSet={srcSetUrls.join(", ")}
+        src={imageUrl + "?" + searchParams.toString()}
+        width={width}
+        height={height}
+        {...props}
+      />
+    </picture>
+  );
+}

--- a/app/features/cms/blocks/hero/editor-schema.test.ts
+++ b/app/features/cms/blocks/hero/editor-schema.test.ts
@@ -40,9 +40,9 @@ describe("hero editor schema image behavior", () => {
 
     expect(parsed.success).toBe(false);
     if (parsed.success) return;
-    expect(parsed.error.issues.some((issue) => issue.path[0] === "imageAlt")).toBe(
-      true,
-    );
+    expect(
+      parsed.error.issues.some((issue) => issue.path[0] === "imageAlt"),
+    ).toBe(true);
   });
 
   test("builds an uploaded decorative image when replacing with upload", () => {

--- a/app/features/cms/blocks/hero/editor-schema.test.ts
+++ b/app/features/cms/blocks/hero/editor-schema.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  applyHeroBlockEditorValue,
+  createHeroBlockEditorFormSchema,
+  getHeroBlockEditorDefaultValue,
+} from "./editor-schema";
+import type { HeroBlockType } from "./model";
+
+import { createLinkTargetRegistry } from "~/features/cms/link-targets";
+
+const linkTargetRegistry = createLinkTargetRegistry([
+  { key: "dinners", label: "Dinners", href: "/dinners" },
+]);
+
+function makeHeroData(
+  image: HeroBlockType["data"]["image"],
+): HeroBlockType["data"] {
+  return {
+    eyebrow: "eyebrow",
+    headline: "headline",
+    description: "description",
+    actions: [{ label: "Join", href: "/dinners" }],
+    image,
+  };
+}
+
+describe("hero editor schema image behavior", () => {
+  test("requires accessibility choice and alt text for descriptive replacement", () => {
+    const schema = createHeroBlockEditorFormSchema(linkTargetRegistry);
+    const parsed = schema.safeParse({
+      eyebrow: "eyebrow",
+      headline: "headline",
+      description: "description",
+      actions: [{ label: "Join", href: "/dinners" }],
+      imageAction: "replace",
+      imageAccessibility: "descriptive",
+      imageAlt: "",
+    });
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.error.issues.some((issue) => issue.path[0] === "imageAlt")).toBe(
+      true,
+    );
+  });
+
+  test("builds an uploaded decorative image when replacing with upload", () => {
+    const next = applyHeroBlockEditorValue(
+      makeHeroData({ kind: "asset", src: "/hero-image.jpg" }),
+      {
+        eyebrow: "eyebrow",
+        headline: "new headline",
+        description: "new description",
+        actions: [{ label: "Join", href: "/dinners" }],
+        imageAction: "replace",
+        imageAccessibility: "decorative",
+        imageAlt: "",
+      },
+      { uploadedImageId: "img_123" },
+    );
+
+    expect(next.image).toEqual({
+      kind: "uploaded",
+      imageId: "img_123",
+      fallbackAssetSrc: "/hero-image.jpg",
+      decorative: true,
+    });
+  });
+
+  test("reverts uploaded image back to default asset on remove action", () => {
+    const next = applyHeroBlockEditorValue(
+      makeHeroData({
+        kind: "uploaded",
+        imageId: "img_123",
+        fallbackAssetSrc: "/hero-image.jpg",
+        decorative: false,
+        alt: "A plated dinner",
+      }),
+      {
+        eyebrow: "eyebrow",
+        headline: "headline",
+        description: "description",
+        actions: [{ label: "Join", href: "/dinners" }],
+        imageAction: "remove",
+        imageAccessibility: "decorative",
+        imageAlt: "",
+      },
+    );
+
+    expect(next.image).toEqual({
+      kind: "asset",
+      src: "/hero-image.jpg",
+    });
+  });
+
+  test("default form values expose keep action and uploaded accessibility state", () => {
+    const defaults = getHeroBlockEditorDefaultValue(
+      makeHeroData({
+        kind: "uploaded",
+        imageId: "img_123",
+        fallbackAssetSrc: "/hero-image.jpg",
+        decorative: false,
+        alt: "A plated dinner",
+      }),
+      linkTargetRegistry,
+    );
+
+    expect(defaults.imageAction).toBe("keep");
+    expect(defaults.imageAccessibility).toBe("descriptive");
+    expect(defaults.imageAlt).toBe("A plated dinner");
+  });
+});

--- a/app/features/cms/blocks/hero/editor-schema.test.ts
+++ b/app/features/cms/blocks/hero/editor-schema.test.ts
@@ -45,6 +45,15 @@ describe("hero editor schema image behavior", () => {
     ).toBe(true);
   });
 
+  test("asset-backed heroes do not preselect replacement accessibility", () => {
+    const defaults = getHeroBlockEditorDefaultValue(
+      makeHeroData({ kind: "asset", src: "/hero-image.jpg" }),
+      linkTargetRegistry,
+    );
+
+    expect(defaults.imageAccessibility).toBe("");
+  });
+
   test("builds an uploaded decorative image when replacing with upload", () => {
     const next = applyHeroBlockEditorValue(
       makeHeroData({ kind: "asset", src: "/hero-image.jpg" }),
@@ -91,6 +100,35 @@ describe("hero editor schema image behavior", () => {
     expect(next.image).toEqual({
       kind: "asset",
       src: "/hero-image.jpg",
+    });
+  });
+
+  test("updates uploaded image accessibility metadata without re-uploading", () => {
+    const next = applyHeroBlockEditorValue(
+      makeHeroData({
+        kind: "uploaded",
+        imageId: "img_123",
+        fallbackAssetSrc: "/hero-image.jpg",
+        decorative: false,
+        alt: "A plated dinner",
+      }),
+      {
+        eyebrow: "eyebrow",
+        headline: "headline",
+        description: "description",
+        actions: [{ label: "Join", href: "/dinners" }],
+        imageAction: "keep",
+        imageAccessibility: "decorative",
+        imageAlt: "",
+      },
+    );
+
+    expect(next.image).toEqual({
+      kind: "uploaded",
+      imageId: "img_123",
+      fallbackAssetSrc: "/hero-image.jpg",
+      decorative: true,
+      alt: undefined,
     });
   });
 

--- a/app/features/cms/blocks/hero/editor-schema.ts
+++ b/app/features/cms/blocks/hero/editor-schema.ts
@@ -11,6 +11,9 @@ export type HeroBlockEditorFormShape = {
   headline: string;
   description: string;
   actions: [{ label: string; href: string }];
+  imageAction: "keep" | "replace" | "remove";
+  imageAccessibility: "decorative" | "descriptive";
+  imageAlt: string;
 };
 
 export type HeroBlockEditorFormValue = {
@@ -18,33 +21,68 @@ export type HeroBlockEditorFormValue = {
   headline: string;
   description?: string;
   actions: [{ label: string; href: string }];
+  imageAction: "keep" | "replace" | "remove";
+  imageAccessibility?: "decorative" | "descriptive";
+  imageAlt?: string;
 };
 
 export function createHeroBlockEditorFormSchema(
   linkTargetRegistry: LinkTargetRegistry,
 ) {
-  return z.object({
-    eyebrow: z
-      .string()
-      .trim()
-      .optional()
-      .transform((value) => (value ? value : undefined)),
-    headline: z
-      .string({ error: "Headline is required" })
-      .trim()
-      .min(1, "Headline is required"),
-    description: z
-      .string()
-      .trim()
-      .optional()
-      .transform((value) => (value ? value : undefined)),
-    actions: z.tuple([
-      createHeroActionSchema(linkTargetRegistry).pick({
-        label: true,
-        href: true,
-      }),
-    ]),
-  });
+  return z
+    .object({
+      eyebrow: z
+        .string()
+        .trim()
+        .optional()
+        .transform((value) => (value ? value : undefined)),
+      headline: z
+        .string({ error: "Headline is required" })
+        .trim()
+        .min(1, "Headline is required"),
+      description: z
+        .string()
+        .trim()
+        .optional()
+        .transform((value) => (value ? value : undefined)),
+      actions: z.tuple([
+        createHeroActionSchema(linkTargetRegistry).pick({
+          label: true,
+          href: true,
+        }),
+      ]),
+      imageAction: z.enum(["keep", "replace", "remove"]).default("keep"),
+      imageAccessibility: z.enum(["decorative", "descriptive"]).optional(),
+      imageAlt: z
+        .string()
+        .trim()
+        .optional()
+        .transform((value) => (value ? value : undefined)),
+    })
+    .superRefine((value, ctx) => {
+      if (value.imageAction !== "replace") {
+        return;
+      }
+
+      if (!value.imageAccessibility) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["imageAccessibility"],
+          message: "Image accessibility choice is required",
+        });
+      }
+
+      if (
+        value.imageAccessibility === "descriptive" &&
+        (!value.imageAlt || value.imageAlt.length === 0)
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["imageAlt"],
+          message: "Alt text is required for descriptive images",
+        });
+      }
+    });
 }
 
 export function getHeroBlockEditorDefaultValue(
@@ -52,6 +90,16 @@ export function getHeroBlockEditorDefaultValue(
   linkTargetRegistry: LinkTargetRegistry,
 ): HeroBlockEditorFormShape {
   const action = data.actions[0];
+  const isUploadedImage = data.image.kind === "uploaded";
+  const imageAccessibility = isUploadedImage
+    ? data.image.decorative
+      ? "decorative"
+      : "descriptive"
+    : "decorative";
+  const imageAlt =
+    isUploadedImage && imageAccessibility === "descriptive"
+      ? data.image.alt ?? ""
+      : "";
 
   return {
     eyebrow: data.eyebrow ?? "",
@@ -63,13 +111,41 @@ export function getHeroBlockEditorDefaultValue(
         href: action?.href ?? linkTargetRegistry.targets[0]?.href ?? "",
       },
     ],
+    imageAction: "keep",
+    imageAccessibility,
+    imageAlt,
   };
 }
 
 export function applyHeroBlockEditorValue(
   currentData: HeroBlockType["data"],
   value: HeroBlockEditorFormValue,
+  options?: {
+    uploadedImageId?: string;
+  },
 ): HeroBlockType["data"] {
+  const currentImage = currentData.image;
+  const image =
+    value.imageAction === "replace" && options?.uploadedImageId
+      ? {
+          kind: "uploaded" as const,
+          imageId: options.uploadedImageId,
+          fallbackAssetSrc:
+            currentImage.kind === "asset"
+              ? currentImage.src
+              : currentImage.fallbackAssetSrc,
+          decorative: value.imageAccessibility !== "descriptive",
+          ...(value.imageAccessibility === "descriptive" && value.imageAlt
+            ? { alt: value.imageAlt }
+            : {}),
+        }
+      : value.imageAction === "remove" && currentImage.kind === "uploaded"
+        ? {
+            kind: "asset" as const,
+            src: currentImage.fallbackAssetSrc,
+          }
+        : currentImage;
+
   return {
     ...currentData,
     eyebrow: value.eyebrow,
@@ -82,6 +158,7 @@ export function applyHeroBlockEditorValue(
         href: value.actions[0].href,
       },
     ],
+    image,
   };
 }
 

--- a/app/features/cms/blocks/hero/editor-schema.ts
+++ b/app/features/cms/blocks/hero/editor-schema.ts
@@ -12,7 +12,7 @@ export type HeroBlockEditorFormShape = {
   description: string;
   actions: [{ label: string; href: string }];
   imageAction: "keep" | "replace" | "remove";
-  imageAccessibility: "decorative" | "descriptive";
+  imageAccessibility: "" | "decorative" | "descriptive";
   imageAlt: string;
 };
 
@@ -52,7 +52,10 @@ export function createHeroBlockEditorFormSchema(
         }),
       ]),
       imageAction: z.enum(["keep", "replace", "remove"]).default("keep"),
-      imageAccessibility: z.enum(["decorative", "descriptive"]).optional(),
+      imageAccessibility: z.preprocess(
+        (value) => (value === "" ? undefined : value),
+        z.enum(["decorative", "descriptive"]).optional(),
+      ),
       imageAlt: z
         .string()
         .trim()
@@ -95,7 +98,7 @@ export function getHeroBlockEditorDefaultValue(
       ? data.image.decorative
         ? "decorative"
         : "descriptive"
-      : "decorative";
+      : "";
   const imageAlt =
     data.image.kind === "uploaded" && imageAccessibility === "descriptive"
       ? (data.image.alt ?? "")
@@ -145,7 +148,18 @@ export function applyHeroBlockEditorValue(
             kind: "asset" as const,
             src: currentImage.fallbackAssetSrc,
           }
-        : currentImage;
+        : value.imageAction === "keep" &&
+            currentImage.kind === "uploaded" &&
+            value.imageAccessibility
+          ? {
+              ...currentImage,
+              decorative: value.imageAccessibility !== "descriptive",
+              alt:
+                value.imageAccessibility === "descriptive"
+                  ? value.imageAlt
+                  : undefined,
+            }
+          : currentImage;
 
   return {
     ...currentData,

--- a/app/features/cms/blocks/hero/editor-schema.ts
+++ b/app/features/cms/blocks/hero/editor-schema.ts
@@ -90,15 +90,15 @@ export function getHeroBlockEditorDefaultValue(
   linkTargetRegistry: LinkTargetRegistry,
 ): HeroBlockEditorFormShape {
   const action = data.actions[0];
-  const isUploadedImage = data.image.kind === "uploaded";
-  const imageAccessibility = isUploadedImage
-    ? data.image.decorative
-      ? "decorative"
-      : "descriptive"
-    : "decorative";
+  const imageAccessibility =
+    data.image.kind === "uploaded"
+      ? data.image.decorative
+        ? "decorative"
+        : "descriptive"
+      : "decorative";
   const imageAlt =
-    isUploadedImage && imageAccessibility === "descriptive"
-      ? data.image.alt ?? ""
+    data.image.kind === "uploaded" && imageAccessibility === "descriptive"
+      ? (data.image.alt ?? "")
       : "";
 
   return {
@@ -135,9 +135,10 @@ export function applyHeroBlockEditorValue(
               ? currentImage.src
               : currentImage.fallbackAssetSrc,
           decorative: value.imageAccessibility !== "descriptive",
-          ...(value.imageAccessibility === "descriptive" && value.imageAlt
-            ? { alt: value.imageAlt }
-            : {}),
+          alt:
+            value.imageAccessibility === "descriptive"
+              ? value.imageAlt
+              : undefined,
         }
       : value.imageAction === "remove" && currentImage.kind === "uploaded"
         ? {

--- a/app/features/cms/blocks/hero/editor.test.tsx
+++ b/app/features/cms/blocks/hero/editor.test.tsx
@@ -18,7 +18,7 @@ function makeCtx(
     headline: "test headline",
     description: "test description",
     actions: [{ label: "Join", href: "/join" }],
-    image: { src: "/hero.jpg" },
+    image: { kind: "asset", src: "/hero.jpg" },
   };
 
   return {
@@ -71,6 +71,14 @@ describe("HeroBlockEditor", () => {
     // The image src should be visible but not in an <input type="text"> that could alter it
     expect(html).toContain("/hero.jpg");
     expect(html).not.toContain(`<input type="text" value="/hero.jpg"`);
+  });
+
+  test("renders image lifecycle and accessibility fields", () => {
+    const html = render(<HeroBlockEditor ctx={makeCtx()} />);
+
+    expect(html).toContain("Image action");
+    expect(html).toContain('name="imageFile"');
+    expect(html).toContain("Image accessibility");
   });
 
   test("shows move-up button when canMoveUp is true", () => {

--- a/app/features/cms/blocks/hero/editor.test.tsx
+++ b/app/features/cms/blocks/hero/editor.test.tsx
@@ -79,6 +79,7 @@ describe("HeroBlockEditor", () => {
     expect(html).toContain("Image action");
     expect(html).toContain('name="imageFile"');
     expect(html).toContain("Image accessibility");
+    expect(html).toContain("Choose accessibility");
   });
 
   test("shows move-up button when canMoveUp is true", () => {

--- a/app/features/cms/blocks/hero/editor.tsx
+++ b/app/features/cms/blocks/hero/editor.tsx
@@ -55,6 +55,7 @@ export function HeroBlockEditor({ ctx }: HeroBlockEditorProps) {
     <div className="flex flex-col gap-4 rounded-md border p-4">
       <form
         method="post"
+        encType="multipart/form-data"
         className="flex flex-col gap-4"
         {...getFormProps(form)}
       >
@@ -81,8 +82,72 @@ export function HeroBlockEditor({ ctx }: HeroBlockEditorProps) {
         ) : null}
 
         <p className="text-muted-foreground text-sm">
-          Image: <span>{data.image.src}</span> (read-only)
+          {data.image.kind === "asset" ? (
+            <>
+              Image: <span>{data.image.src}</span> (default asset, read-only)
+            </>
+          ) : (
+            <>
+              Image: <span>{`/file/${data.image.imageId}`}</span> (CMS upload)
+            </>
+          )}
         </p>
+
+        <SelectField
+          labelProps={{ children: "Image action" }}
+          selectProps={{
+            ...getSelectProps(fields.imageAction),
+            children: (
+              <>
+                <option value="keep">Keep current image</option>
+                <option value="replace">Replace with uploaded image</option>
+                {data.image.kind === "uploaded" ? (
+                  <option value="remove">Use default asset image</option>
+                ) : null}
+              </>
+            ),
+            className:
+              "focus-visible:border-0 flex h-9 w-full appearance-none rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground file:placeholder:text-foreground focus-visible:outline-hidden focus-visible:inset-ring-2 focus-visible:inset-ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          }}
+          errors={fields.imageAction.errors}
+          className="flex flex-col gap-2"
+        />
+
+        <Field
+          labelProps={{ children: "Upload image file" }}
+          inputProps={{
+            name: "imageFile",
+            id: `${formId}-imageFile`,
+            type: "file",
+            accept: "image/*",
+          }}
+          errors={undefined}
+          className="flex flex-col gap-2"
+        />
+
+        <SelectField
+          labelProps={{ children: "Image accessibility" }}
+          selectProps={{
+            ...getSelectProps(fields.imageAccessibility),
+            children: (
+              <>
+                <option value="decorative">Decorative image</option>
+                <option value="descriptive">Descriptive image</option>
+              </>
+            ),
+            className:
+              "focus-visible:border-0 flex h-9 w-full appearance-none rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground file:placeholder:text-foreground focus-visible:outline-hidden focus-visible:inset-ring-2 focus-visible:inset-ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          }}
+          errors={fields.imageAccessibility.errors}
+          className="flex flex-col gap-2"
+        />
+
+        <Field
+          labelProps={{ children: "Image alt text" }}
+          inputProps={{ ...getInputProps(fields.imageAlt, { type: "text" }) }}
+          errors={fields.imageAlt.errors}
+          className="flex flex-col gap-2"
+        />
 
         <Field
           labelProps={{ children: "Eyebrow" }}

--- a/app/features/cms/blocks/hero/editor.tsx
+++ b/app/features/cms/blocks/hero/editor.tsx
@@ -131,6 +131,7 @@ export function HeroBlockEditor({ ctx }: HeroBlockEditorProps) {
             ...getSelectProps(fields.imageAccessibility),
             children: (
               <>
+                <option value="">Choose accessibility</option>
                 <option value="decorative">Decorative image</option>
                 <option value="descriptive">Descriptive image</option>
               </>

--- a/app/features/cms/blocks/hero/model.ts
+++ b/app/features/cms/blocks/hero/model.ts
@@ -1,11 +1,40 @@
 import { z } from "zod/v4";
 
 import type { LinkTargetRegistry } from "../../link-targets";
-import { ActionSchema, ImageSchema } from "../models";
+import { ActionSchema } from "../models";
 import type { BlockBaseType, BlockType, BlockVersion } from "../types";
 
 const BLOCK_TYPE: BlockType = "hero";
 const BLOCK_VERSION: BlockVersion = 1;
+
+const HeroAssetImageSchema = z.object({
+  kind: z.literal("asset"),
+  src: z.string(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+});
+
+const HeroUploadedImageSchema = z
+  .object({
+    kind: z.literal("uploaded"),
+    imageId: z.string().trim().min(1),
+    fallbackAssetSrc: z.string().trim().min(1),
+    decorative: z.boolean(),
+    alt: z
+      .string()
+      .trim()
+      .optional()
+      .transform((value) => (value ? value : undefined)),
+  })
+  .superRefine((image, ctx) => {
+    if (!image.decorative && !image.alt) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["alt"],
+        message: "Alt text is required when image is descriptive",
+      });
+    }
+  });
 
 function optionalCopyFieldSchema() {
   return z
@@ -49,7 +78,10 @@ export function createHeroBlockDataSchema(
     actions: z
       .array(createHeroActionSchema(linkTargetRegistry))
       .min(1, "At least one CTA is required"),
-    image: ImageSchema,
+    image: z.discriminatedUnion("kind", [
+      HeroAssetImageSchema,
+      HeroUploadedImageSchema,
+    ]),
   });
 }
 

--- a/app/features/cms/blocks/hero/view.tsx
+++ b/app/features/cms/blocks/hero/view.tsx
@@ -6,6 +6,7 @@ import { generateSrcSet } from "../utils";
 import type { HeroBlockType } from "./model";
 
 import { Button } from "~/components/ui/button";
+import { getImageUrl } from "~/utils/misc";
 
 type HeroBlockViewProps = React.ComponentPropsWithoutRef<"section"> & {
   blockData: HeroBlockType;
@@ -14,7 +15,10 @@ type HeroBlockViewProps = React.ComponentPropsWithoutRef<"section"> & {
 export function HeroBlockView({ blockData, ...rest }: HeroBlockViewProps) {
   const { data } = blockData;
   const { eyebrow, headline, description, actions = [], image } = data;
-  const { src, alt, width, height } = image;
+  const src = image.kind === "asset" ? image.src : getImageUrl(image.imageId);
+  const alt = image.kind === "asset" ? "" : image.decorative ? "" : image.alt;
+  const width = image.kind === "asset" ? image.width : undefined;
+  const height = image.kind === "asset" ? image.height : undefined;
   const srcSet = generateSrcSet(src, [432, 648, 864, 1080]);
 
   return (

--- a/app/features/cms/blocks/hero/view.tsx
+++ b/app/features/cms/blocks/hero/view.tsx
@@ -5,6 +5,7 @@ import { generateSrcSet } from "../utils";
 
 import type { HeroBlockType } from "./model";
 
+import { OptimizedImage } from "~/components/optimized-image";
 import { Button } from "~/components/ui/button";
 import { getImageUrl } from "~/utils/misc";
 
@@ -73,17 +74,27 @@ export function HeroBlockView({ blockData, ...rest }: HeroBlockViewProps) {
 
         <div className="mx-auto flex not-lg:mt-10">
           <div className="max-w-3xl flex-none not-md:pl-4 md:max-w-3xl lg:max-w-4xl 2xl:max-w-none">
-            <picture>
-              <img
-                srcSet={srcSet}
-                src={src}
-                className="w-304 rounded-md object-center"
-                fetchPriority="high"
-                width={width}
-                height={height}
+            {image.kind === "asset" ? (
+              <picture>
+                <img
+                  srcSet={srcSet}
+                  src={src}
+                  className="w-304 rounded-md object-center"
+                  fetchPriority="high"
+                  width={width}
+                  height={height}
+                  alt={alt}
+                />
+              </picture>
+            ) : (
+              <OptimizedImage
+                imageId={image.imageId}
                 alt={alt}
+                width={640}
+                height={480}
+                className="w-304 rounded-md object-center"
               />
-            </picture>
+            )}
           </div>
         </div>
       </div>

--- a/app/features/cms/blocks/hero/view.tsx
+++ b/app/features/cms/blocks/hero/view.tsx
@@ -92,6 +92,7 @@ export function HeroBlockView({ blockData, ...rest }: HeroBlockViewProps) {
                 alt={alt}
                 width={640}
                 height={480}
+                sizes="(min-width: 1024px) 640px, (min-width: 768px) 50vw, 100vw"
                 className="w-304 rounded-md object-center"
               />
             )}

--- a/app/features/cms/cms-image-lifecycle.server.test.ts
+++ b/app/features/cms/cms-image-lifecycle.server.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { BlockInstance } from "./catalog";
+import {
+  collectUploadedHeroImageIdsFromBlocks,
+  deleteCmsImagesIfUnreferenced,
+} from "./cms-image-lifecycle.server";
+
+describe("cms image lifecycle", () => {
+  test("collects uploaded hero image ids from page blocks", () => {
+    const blocks: BlockInstance[] = [
+      {
+        type: "hero",
+        version: 1,
+        data: {
+          headline: "hero",
+          actions: [{ label: "Join", href: "/dinners" }],
+          image: {
+            kind: "uploaded",
+            imageId: "img_123",
+            fallbackAssetSrc: "/hero-image.jpg",
+            decorative: true,
+          },
+        },
+      },
+      {
+        type: "text-section",
+        version: 1,
+        data: { headline: "x", body: "y", variant: "plain" },
+      },
+    ];
+
+    expect([...collectUploadedHeroImageIdsFromBlocks(blocks)]).toEqual([
+      "img_123",
+    ]);
+  });
+
+  test("deletes candidate image when no references remain", async () => {
+    const prisma = {
+      pageBlock: {
+        count: vi.fn().mockResolvedValue(0),
+      },
+      event: {
+        count: vi.fn().mockResolvedValue(0),
+      },
+      image: {
+        count: vi.fn().mockResolvedValue(0),
+        delete: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await deleteCmsImagesIfUnreferenced({
+      prisma: prisma as never,
+      imageIds: ["img_123"],
+    });
+
+    expect(prisma.image.delete).toHaveBeenCalledWith({
+      where: { id: "img_123" },
+    });
+  });
+
+  test("does not delete candidate image when still referenced by a page block", async () => {
+    const prisma = {
+      pageBlock: {
+        count: vi.fn().mockResolvedValue(1),
+      },
+      event: {
+        count: vi.fn().mockResolvedValue(0),
+      },
+      image: {
+        count: vi.fn().mockResolvedValue(0),
+        delete: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await deleteCmsImagesIfUnreferenced({
+      prisma: prisma as never,
+      imageIds: ["img_123"],
+    });
+
+    expect(prisma.image.delete).not.toHaveBeenCalled();
+  });
+});

--- a/app/features/cms/cms-image-lifecycle.server.test.ts
+++ b/app/features/cms/cms-image-lifecycle.server.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import type { BlockInstance } from "./catalog";
 import {
   collectUploadedHeroImageIdsFromBlocks,
+  getRemovedUploadedHeroImageIds,
   deleteCmsImagesIfUnreferenced,
 } from "./cms-image-lifecycle.server";
 
@@ -57,6 +58,77 @@ describe("cms image lifecycle", () => {
     expect(prisma.image.delete).toHaveBeenCalledWith({
       where: { id: "img_123" },
     });
+  });
+
+  test("finds uploaded hero images removed by a replace or remove edit", () => {
+    const previousBlocks: BlockInstance[] = [
+      {
+        pageBlockId: "hero-1",
+        type: "hero",
+        version: 1,
+        data: {
+          headline: "hero",
+          actions: [{ label: "Join", href: "/dinners" }],
+          image: {
+            kind: "uploaded",
+            imageId: "img_old",
+            fallbackAssetSrc: "/hero-image.jpg",
+            decorative: true,
+          },
+        },
+      },
+    ];
+    const nextBlocks: BlockInstance[] = [
+      {
+        pageBlockId: "hero-1",
+        type: "hero",
+        version: 1,
+        data: {
+          headline: "hero",
+          actions: [{ label: "Join", href: "/dinners" }],
+          image: {
+            kind: "uploaded",
+            imageId: "img_new",
+            fallbackAssetSrc: "/hero-image.jpg",
+            decorative: true,
+          },
+        },
+      },
+    ];
+
+    expect(getRemovedUploadedHeroImageIds(previousBlocks, nextBlocks)).toEqual([
+      "img_old",
+    ]);
+  });
+
+  test("finds uploaded hero images removed when the block disappears", () => {
+    const previousBlocks: BlockInstance[] = [
+      {
+        pageBlockId: "hero-1",
+        type: "hero",
+        version: 1,
+        data: {
+          headline: "hero",
+          actions: [{ label: "Join", href: "/dinners" }],
+          image: {
+            kind: "uploaded",
+            imageId: "img_old",
+            fallbackAssetSrc: "/hero-image.jpg",
+            decorative: true,
+          },
+        },
+      },
+      {
+        pageBlockId: "text-1",
+        type: "text-section",
+        version: 1,
+        data: { headline: "x", body: "y", variant: "plain" },
+      },
+    ];
+
+    expect(getRemovedUploadedHeroImageIds(previousBlocks, [])).toEqual([
+      "img_old",
+    ]);
   });
 
   test("does not delete candidate image when still referenced by a page block", async () => {

--- a/app/features/cms/cms-image-lifecycle.server.ts
+++ b/app/features/cms/cms-image-lifecycle.server.ts
@@ -41,6 +41,17 @@ export function collectUploadedHeroImageIdsFromBlocks(
   return imageIds;
 }
 
+export function getRemovedUploadedHeroImageIds(
+  previousBlocks: readonly BlockInstance[],
+  nextBlocks: readonly BlockInstance[],
+): string[] {
+  const nextImageIds = collectUploadedHeroImageIdsFromBlocks(nextBlocks);
+
+  return [...collectUploadedHeroImageIdsFromBlocks(previousBlocks)].filter(
+    (imageId) => !nextImageIds.has(imageId),
+  );
+}
+
 export async function deleteCmsImagesIfUnreferenced({
   imageIds,
   prisma,

--- a/app/features/cms/cms-image-lifecycle.server.ts
+++ b/app/features/cms/cms-image-lifecycle.server.ts
@@ -1,0 +1,71 @@
+import type { BlockInstance } from "./catalog";
+
+type CmsImageLifecyclePrisma = {
+  pageBlock: {
+    count(args: { where: { data: { contains: string } } }): Promise<number>;
+  };
+  event: {
+    count(args: { where: { imageId: string } }): Promise<number>;
+  };
+  image: {
+    count(args: { where: { id: string; boardMemberId: { not: null } } }): Promise<number>;
+    delete(args: { where: { id: string } }): Promise<unknown>;
+  };
+};
+
+export function collectUploadedHeroImageIdsFromBlocks(
+  blocks: readonly BlockInstance[],
+): Set<string> {
+  const imageIds = new Set<string>();
+
+  for (const block of blocks) {
+    if (block.type !== "hero") continue;
+
+    const data = block.data as {
+      image?: {
+        kind?: string;
+        imageId?: string;
+      };
+    };
+
+    if (data.image?.kind === "uploaded" && typeof data.image.imageId === "string") {
+      imageIds.add(data.image.imageId);
+    }
+  }
+
+  return imageIds;
+}
+
+export async function deleteCmsImagesIfUnreferenced({
+  imageIds,
+  prisma,
+}: {
+  imageIds: readonly string[];
+  prisma: CmsImageLifecyclePrisma;
+}) {
+  const uniqueIds = [...new Set(imageIds.filter((id) => id.length > 0))];
+
+  for (const imageId of uniqueIds) {
+    const [pageReferences, eventReferences, boardMemberReferences] = await Promise.all([
+      prisma.pageBlock.count({
+        where: { data: { contains: `"imageId":"${imageId}"` } },
+      }),
+      prisma.event.count({
+        where: { imageId },
+      }),
+      prisma.image.count({
+        where: { id: imageId, boardMemberId: { not: null } },
+      }),
+    ]);
+
+    if (pageReferences > 0 || eventReferences > 0 || boardMemberReferences > 0) {
+      continue;
+    }
+
+    try {
+      await prisma.image.delete({ where: { id: imageId } });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}

--- a/app/features/cms/cms-image-lifecycle.server.ts
+++ b/app/features/cms/cms-image-lifecycle.server.ts
@@ -8,7 +8,9 @@ type CmsImageLifecyclePrisma = {
     count(args: { where: { imageId: string } }): Promise<number>;
   };
   image: {
-    count(args: { where: { id: string; boardMemberId: { not: null } } }): Promise<number>;
+    count(args: {
+      where: { id: string; boardMemberId: { not: null } };
+    }): Promise<number>;
     delete(args: { where: { id: string } }): Promise<unknown>;
   };
 };
@@ -28,7 +30,10 @@ export function collectUploadedHeroImageIdsFromBlocks(
       };
     };
 
-    if (data.image?.kind === "uploaded" && typeof data.image.imageId === "string") {
+    if (
+      data.image?.kind === "uploaded" &&
+      typeof data.image.imageId === "string"
+    ) {
       imageIds.add(data.image.imageId);
     }
   }
@@ -46,19 +51,24 @@ export async function deleteCmsImagesIfUnreferenced({
   const uniqueIds = [...new Set(imageIds.filter((id) => id.length > 0))];
 
   for (const imageId of uniqueIds) {
-    const [pageReferences, eventReferences, boardMemberReferences] = await Promise.all([
-      prisma.pageBlock.count({
-        where: { data: { contains: `"imageId":"${imageId}"` } },
-      }),
-      prisma.event.count({
-        where: { imageId },
-      }),
-      prisma.image.count({
-        where: { id: imageId, boardMemberId: { not: null } },
-      }),
-    ]);
+    const [pageReferences, eventReferences, boardMemberReferences] =
+      await Promise.all([
+        prisma.pageBlock.count({
+          where: { data: { contains: `"imageId":"${imageId}"` } },
+        }),
+        prisma.event.count({
+          where: { imageId },
+        }),
+        prisma.image.count({
+          where: { id: imageId, boardMemberId: { not: null } },
+        }),
+      ]);
 
-    if (pageReferences > 0 || eventReferences > 0 || boardMemberReferences > 0) {
+    if (
+      pageReferences > 0 ||
+      eventReferences > 0 ||
+      boardMemberReferences > 0
+    ) {
       continue;
     }
 

--- a/app/features/cms/page-service.server.test.ts
+++ b/app/features/cms/page-service.server.test.ts
@@ -548,7 +548,9 @@ describe("createCmsPageService — block commands", () => {
     const defaultHeroData = defaultSnapshot.blocks[0].data as {
       headline: string;
       actions: { href: string; label: string }[];
-      image: { src: string };
+      image:
+        | { kind: "asset"; src: string }
+        | { kind: "uploaded"; imageId: string };
     };
 
     const result = await service.applyPageCommand({

--- a/app/features/cms/pages/home.ts
+++ b/app/features/cms/pages/home.ts
@@ -14,6 +14,7 @@ const heroBlock: HeroBlockType = {
       "A dinner society in Zurich, bringing people together through shared meals, stories, and the joy of discovery.",
     actions: [{ href: "/dinners", label: "join a dinner" }],
     image: {
+      kind: "asset",
       src: "/hero-image.jpg",
     },
   },

--- a/app/routes/admin.board-members.tsx
+++ b/app/routes/admin.board-members.tsx
@@ -2,8 +2,8 @@ import { ChevronRightIcon, PersonIcon } from "@radix-ui/react-icons";
 import { Link, Outlet, useLoaderData } from "react-router";
 
 import type { Route } from "./+types/admin.board-members";
-import { OptimizedImage } from "./file.$fileId";
 
+import { OptimizedImage } from "~/components/optimized-image";
 import { prisma } from "~/db.server";
 import { requireUserWithRole } from "~/utils/session.server";
 

--- a/app/routes/admin.pages.$pageKey.tsx
+++ b/app/routes/admin.pages.$pageKey.tsx
@@ -30,7 +30,10 @@ import type {
   BlockEditorContext,
   BlockInstance,
 } from "~/features/cms/catalog";
-import { deleteCmsImagesIfUnreferenced } from "~/features/cms/cms-image-lifecycle.server";
+import {
+  deleteCmsImagesIfUnreferenced,
+  getRemovedUploadedHeroImageIds,
+} from "~/features/cms/cms-image-lifecycle.server";
 import {
   createPageCommandBuilder,
   type MutableBlockRef,
@@ -302,9 +305,9 @@ export async function action({ request, params }: Route.ActionArgs) {
       }
 
       if (previousImageId && previousImageId !== nextImageId) {
-        await deleteCmsImagesIfUnreferenced({
-          imageIds: [previousImageId],
-          prisma,
+        await cleanupRemovedHeroImages({
+          previousBlocks: currentBlocks,
+          nextBlocks: result.editorModel.pageSnapshot.blocks,
         });
       }
 
@@ -345,6 +348,8 @@ export async function action({ request, params }: Route.ActionArgs) {
         });
       }
 
+      const currentEditorModel =
+        await siteCmsPageService.readEditorModel(pageKey);
       const mutableRef: MutableBlockRef = blockRef;
       const command = commandBuilder.deleteBlock(mutableRef);
       const result = await siteCmsPageService.applyPageCommand(command);
@@ -357,6 +362,11 @@ export async function action({ request, params }: Route.ActionArgs) {
           editorModel: result.currentEditorModel,
         };
       }
+
+      await cleanupRemovedHeroImages({
+        previousBlocks: currentEditorModel.pageSnapshot.blocks,
+        nextBlocks: result.editorModel.pageSnapshot.blocks,
+      });
 
       return redirect(`/admin/pages/${pageKey}`);
     }
@@ -378,6 +388,28 @@ async function persistHeroUploadedImage(
   }
 
   return upload.persistImage(fileEntry);
+}
+
+async function cleanupRemovedHeroImages({
+  previousBlocks,
+  nextBlocks,
+}: {
+  previousBlocks: readonly BlockInstance[];
+  nextBlocks: readonly BlockInstance[];
+}) {
+  const removedImageIds = getRemovedUploadedHeroImageIds(
+    previousBlocks,
+    nextBlocks,
+  );
+
+  if (removedImageIds.length === 0) {
+    return;
+  }
+
+  await deleteCmsImagesIfUnreferenced({
+    imageIds: removedImageIds,
+    prisma,
+  });
 }
 
 function getUploadedHeroImageId(blockData: unknown): string | null {

--- a/app/routes/admin.pages.$pageKey.tsx
+++ b/app/routes/admin.pages.$pageKey.tsx
@@ -14,6 +14,7 @@ import type { Route } from "./+types/admin.pages.$pageKey";
 
 import { Field, TextareaField } from "~/components/forms";
 import { Button } from "~/components/ui/button";
+import { prisma } from "~/db.server";
 import type { BlockRef } from "~/features/cms/blocks/block-ref";
 import {
   refByDefinitionKey,
@@ -29,6 +30,7 @@ import type {
   BlockEditorContext,
 } from "~/features/cms/catalog";
 import type { BlockInstance } from "~/features/cms/catalog";
+import { deleteCmsImagesIfUnreferenced } from "~/features/cms/cms-image-lifecycle.server";
 import {
   createPageCommandBuilder,
   type MutableBlockRef,
@@ -200,6 +202,19 @@ export async function action({ request, params }: Route.ActionArgs) {
       };
     }
 
+    const uploadedImageId =
+      heroSubmission.value.imageAction === "replace"
+        ? await persistHeroUploadedImage(formData.get("imageFile"))
+        : undefined;
+    if (heroSubmission.value.imageAction === "replace" && !uploadedImageId) {
+      return {
+        status: "block-conflict" as const,
+        blockRef: serializedBlockRef,
+        conflictMessage: "Please choose an image file before replacing.",
+        editorModel: currentEditorModel,
+      };
+    }
+
     const command = commandBuilder.setBlockData(
       blockRef,
       blockType as BlockType,
@@ -207,18 +222,39 @@ export async function action({ request, params }: Route.ActionArgs) {
       applyHeroBlockEditorValue(
         currentBlock.data as Parameters<typeof applyHeroBlockEditorValue>[0],
         heroSubmission.value,
+        { uploadedImageId },
       ),
     );
+    const nextData = command.data as Parameters<typeof getUploadedHeroImageId>[0];
+    const previousImageId = getUploadedHeroImageId(currentBlock.data);
+    const nextImageId = getUploadedHeroImageId(nextData);
 
     const result = await siteCmsPageService.applyPageCommand(command);
 
     if (result.status === "conflict") {
+      if (
+        heroSubmission.value.imageAction === "replace" &&
+        nextImageId &&
+        nextImageId !== previousImageId
+      ) {
+        await deleteCmsImagesIfUnreferenced({
+          imageIds: [nextImageId],
+          prisma,
+        });
+      }
       return {
         status: "block-conflict" as const,
         blockRef: serializedBlockRef,
         conflictMessage: "Block could not be saved — please refresh and retry.",
         editorModel: result.currentEditorModel,
       };
+    }
+
+    if (previousImageId && previousImageId !== nextImageId) {
+      await deleteCmsImagesIfUnreferenced({
+        imageIds: [previousImageId],
+        prisma,
+      });
     }
 
     return redirect(`/admin/pages/${pageKey}`);
@@ -275,6 +311,37 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   throw new Response(`Unknown intent: ${String(intent)}`, { status: 400 });
+}
+
+async function persistHeroUploadedImage(
+  fileEntry: FormDataEntryValue | null,
+): Promise<string | undefined> {
+  if (!(fileEntry instanceof File) || fileEntry.size <= 0) {
+    return undefined;
+  }
+
+  const image = await prisma.image.create({
+    data: {
+      contentType: fileEntry.type || "application/octet-stream",
+      blob: Buffer.from(await fileEntry.arrayBuffer()),
+    },
+  });
+  return image.id;
+}
+
+function getUploadedHeroImageId(blockData: unknown): string | null {
+  const data = blockData as {
+    image?: {
+      kind?: string;
+      imageId?: string;
+    };
+  };
+
+  if (data.image?.kind !== "uploaded" || !data.image.imageId) {
+    return null;
+  }
+
+  return data.image.imageId;
 }
 
 function resolveBlock(

--- a/app/routes/admin.pages.$pageKey.tsx
+++ b/app/routes/admin.pages.$pageKey.tsx
@@ -28,8 +28,8 @@ import type { BlockType } from "~/features/cms/blocks/types";
 import type {
   BlockEditorCapabilities,
   BlockEditorContext,
+  BlockInstance,
 } from "~/features/cms/catalog";
-import type { BlockInstance } from "~/features/cms/catalog";
 import { deleteCmsImagesIfUnreferenced } from "~/features/cms/cms-image-lifecycle.server";
 import {
   createPageCommandBuilder,
@@ -40,6 +40,7 @@ import { formatPageStatus } from "~/features/cms/page-status";
 import { siteCmsCatalog } from "~/features/cms/site-catalog";
 import { siteLinkTargetRegistry } from "~/features/cms/site-link-targets";
 import { siteCmsPageService } from "~/features/cms/site-page-service.server";
+import { parseImageFormData } from "~/utils/image-upload.server";
 import { requireUserWithRole } from "~/utils/session.server";
 
 // ─── Schemas ──────────────────────────────────────────────────────────────────
@@ -60,6 +61,8 @@ const PageMetaSchema = z.object({
     .transform((v) => (v === undefined || v === "" ? null : Number(v)))
     .pipe(z.number().int().nonnegative().nullable()),
 });
+
+const MAX_IMAGE_SIZE_BYTES = 1024 * 1024 * 3;
 
 // ─── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -116,217 +119,265 @@ export async function action({ request, params }: Route.ActionArgs) {
   await requireUserWithRole(request, ["moderator", "admin"]);
 
   const pageKey = requireKnownPageKey(params.pageKey);
-  const formData = await request.formData();
+  const uploadResult = await parseImageFormData(request, "imageFile");
+
+  if (!uploadResult.success) {
+    return {
+      status: "conflict" as const,
+      conflictMessage: uploadResult.uploadError,
+      editorModel: await siteCmsPageService.readEditorModel(pageKey),
+    };
+  }
+
+  const formData = uploadResult.formData;
   const intent = formData.get("intent");
 
-  // Default (no intent field) → set-page-meta via Conform
-  if (!intent || intent === "set-page-meta") {
-    const submission = parseWithZod(formData, { schema: PageMetaSchema });
+  try {
+    // Default (no intent field) → set-page-meta via Conform
+    if (!intent || intent === "set-page-meta") {
+      const submission = parseWithZod(formData, { schema: PageMetaSchema });
 
-    if (submission.status !== "success" || !submission.value) {
-      return submission.reply();
-    }
+      if (submission.status !== "success" || !submission.value) {
+        return submission.reply();
+      }
 
-    const command: PageCommand = {
-      type: "set-page-meta",
-      pageKey,
-      baseRevision: submission.value.revision,
-      title: submission.value.title,
-      description: submission.value.description,
-    };
-
-    const result = await siteCmsPageService.applyPageCommand(command);
-
-    if (result.status === "conflict") {
-      return {
-        status: "conflict" as const,
-        conflictMessage:
-          "This page was changed by someone else. The editor has been refreshed with the current values - please review and save again.",
-        editorModel: result.currentEditorModel,
+      const command: PageCommand = {
+        type: "set-page-meta",
+        pageKey,
+        baseRevision: submission.value.revision,
+        title: submission.value.title,
+        description: submission.value.description,
       };
+
+      const result = await siteCmsPageService.applyPageCommand(command);
+
+      if (result.status === "conflict") {
+        return {
+          status: "conflict" as const,
+          conflictMessage:
+            "This page was changed by someone else. The editor has been refreshed with the current values - please review and save again.",
+          editorModel: result.currentEditorModel,
+        };
+      }
+
+      return redirect(`/admin/pages/${pageKey}`);
     }
 
-    return redirect(`/admin/pages/${pageKey}`);
-  }
+    // Block commands — all share blockRef + baseRevision
+    const blockRef = parseBlockRef(formData.get("blockRef"));
+    const baseRevision = parseBaseRevision(formData.get("baseRevision"));
 
-  // Block commands — all share blockRef + baseRevision
-  const blockRef = parseBlockRef(formData.get("blockRef"));
-  const baseRevision = parseBaseRevision(formData.get("baseRevision"));
-
-  if (!blockRef) {
-    throw new Response("Missing or invalid blockRef", { status: 400 });
-  }
-
-  const commandBuilder = createPageCommandBuilder(pageKey, baseRevision);
-
-  if (intent === "set-block-data") {
-    const blockType = formData.get("blockType");
-    const blockVersionRaw = formData.get("blockVersion");
-
-    if (typeof blockType !== "string" || typeof blockVersionRaw !== "string") {
-      throw new Response("Missing blockType or blockVersion", { status: 400 });
+    if (!blockRef) {
+      throw new Response("Missing or invalid blockRef", { status: 400 });
     }
 
-    const blockVersion = Number(blockVersionRaw);
-    const serializedBlockRef = JSON.stringify(blockRef);
+    const commandBuilder = createPageCommandBuilder(pageKey, baseRevision);
 
-    if (blockType !== "hero" || blockVersion !== 1) {
-      throw new Response("Unsupported block editor payload", { status: 400 });
-    }
+    if (intent === "set-block-data") {
+      const blockType = formData.get("blockType");
+      const blockVersionRaw = formData.get("blockVersion");
 
-    const heroSchema = createHeroBlockEditorFormSchema(siteLinkTargetRegistry);
-    const heroSubmission = parseWithZod(formData, {
-      schema: heroSchema,
-    });
+      if (
+        typeof blockType !== "string" ||
+        typeof blockVersionRaw !== "string"
+      ) {
+        throw new Response("Missing blockType or blockVersion", {
+          status: 400,
+        });
+      }
 
-    if (heroSubmission.status !== "success" || !heroSubmission.value) {
-      return {
-        status: "block-validation-error" as const,
-        blockRef: serializedBlockRef,
-        editorModel: await siteCmsPageService.readEditorModel(pageKey),
-        lastResult: heroSubmission.reply(),
-      };
-    }
+      const blockVersion = Number(blockVersionRaw);
+      const serializedBlockRef = JSON.stringify(blockRef);
 
-    const currentEditorModel =
-      await siteCmsPageService.readEditorModel(pageKey);
-    const currentBlocks = currentEditorModel.pageSnapshot.blocks;
-    const currentBlock = resolveBlock(currentBlocks, blockRef);
-    if (!currentBlock || currentBlock.type !== "hero") {
-      return {
-        status: "block-conflict" as const,
-        blockRef: serializedBlockRef,
-        conflictMessage:
-          "Block could not be saved — the editor has been refreshed with the current block.",
-        editorModel: currentEditorModel,
-      };
-    }
+      if (blockType !== "hero" || blockVersion !== 1) {
+        throw new Response("Unsupported block editor payload", { status: 400 });
+      }
 
-    const uploadedImageId =
-      heroSubmission.value.imageAction === "replace"
-        ? await persistHeroUploadedImage(formData.get("imageFile"))
-        : undefined;
-    if (heroSubmission.value.imageAction === "replace" && !uploadedImageId) {
-      return {
-        status: "block-conflict" as const,
-        blockRef: serializedBlockRef,
-        conflictMessage: "Please choose an image file before replacing.",
-        editorModel: currentEditorModel,
-      };
-    }
+      const heroSchema = createHeroBlockEditorFormSchema(
+        siteLinkTargetRegistry,
+      );
+      const heroSubmission = parseWithZod(formData, {
+        schema: heroSchema,
+      });
 
-    const command = commandBuilder.setBlockData(
-      blockRef,
-      blockType as BlockType,
-      blockVersion,
-      applyHeroBlockEditorValue(
-        currentBlock.data as Parameters<typeof applyHeroBlockEditorValue>[0],
-        heroSubmission.value,
-        { uploadedImageId },
-      ),
-    );
-    const nextData = command.data as Parameters<typeof getUploadedHeroImageId>[0];
-    const previousImageId = getUploadedHeroImageId(currentBlock.data);
-    const nextImageId = getUploadedHeroImageId(nextData);
+      if (heroSubmission.status !== "success" || !heroSubmission.value) {
+        return {
+          status: "block-validation-error" as const,
+          blockRef: serializedBlockRef,
+          editorModel: await siteCmsPageService.readEditorModel(pageKey),
+          lastResult: heroSubmission.reply(),
+        };
+      }
 
-    const result = await siteCmsPageService.applyPageCommand(command);
+      const currentEditorModel =
+        await siteCmsPageService.readEditorModel(pageKey);
+      const currentBlocks = currentEditorModel.pageSnapshot.blocks;
+      const currentBlock = resolveBlock(currentBlocks, blockRef);
+      if (!currentBlock || currentBlock.type !== "hero") {
+        return {
+          status: "block-conflict" as const,
+          blockRef: serializedBlockRef,
+          conflictMessage:
+            "Block could not be saved — the editor has been refreshed with the current block.",
+          editorModel: currentEditorModel,
+        };
+      }
 
-    if (result.status === "conflict") {
+      const imageFileEntry = formData.get("imageFile");
       if (
         heroSubmission.value.imageAction === "replace" &&
-        nextImageId &&
-        nextImageId !== previousImageId
+        (!(imageFileEntry instanceof File) || imageFileEntry.size <= 0)
       ) {
+        return {
+          status: "block-conflict" as const,
+          blockRef: serializedBlockRef,
+          conflictMessage: "Please choose an image file before replacing.",
+          editorModel: currentEditorModel,
+        };
+      }
+
+      if (
+        imageFileEntry instanceof File &&
+        imageFileEntry.size > MAX_IMAGE_SIZE_BYTES
+      ) {
+        return {
+          status: "block-conflict" as const,
+          blockRef: serializedBlockRef,
+          conflictMessage: "File cannot be greater than 3MB",
+          editorModel: currentEditorModel,
+        };
+      }
+
+      const uploadedImageId =
+        heroSubmission.value.imageAction === "replace"
+          ? await persistHeroUploadedImage(imageFileEntry, {
+              persistImage: uploadResult.persistImage,
+            })
+          : undefined;
+      if (heroSubmission.value.imageAction === "replace" && !uploadedImageId) {
+        return {
+          status: "block-conflict" as const,
+          blockRef: serializedBlockRef,
+          conflictMessage: "Please choose an image file before replacing.",
+          editorModel: currentEditorModel,
+        };
+      }
+
+      const command = commandBuilder.setBlockData(
+        blockRef,
+        blockType as BlockType,
+        blockVersion,
+        applyHeroBlockEditorValue(
+          currentBlock.data as Parameters<typeof applyHeroBlockEditorValue>[0],
+          heroSubmission.value,
+          { uploadedImageId },
+        ),
+      );
+      const nextData = command.data as Parameters<
+        typeof getUploadedHeroImageId
+      >[0];
+      const previousImageId = getUploadedHeroImageId(currentBlock.data);
+      const nextImageId = getUploadedHeroImageId(nextData);
+
+      const result = await siteCmsPageService.applyPageCommand(command);
+
+      if (result.status === "conflict") {
+        if (
+          heroSubmission.value.imageAction === "replace" &&
+          nextImageId &&
+          nextImageId !== previousImageId
+        ) {
+          await deleteCmsImagesIfUnreferenced({
+            imageIds: [nextImageId],
+            prisma,
+          });
+        }
+        return {
+          status: "block-conflict" as const,
+          blockRef: serializedBlockRef,
+          conflictMessage:
+            "Block could not be saved — please refresh and retry.",
+          editorModel: result.currentEditorModel,
+        };
+      }
+
+      if (previousImageId && previousImageId !== nextImageId) {
         await deleteCmsImagesIfUnreferenced({
-          imageIds: [nextImageId],
+          imageIds: [previousImageId],
           prisma,
         });
       }
-      return {
-        status: "block-conflict" as const,
-        blockRef: serializedBlockRef,
-        conflictMessage: "Block could not be saved — please refresh and retry.",
-        editorModel: result.currentEditorModel,
-      };
+
+      return redirect(`/admin/pages/${pageKey}`);
     }
 
-    if (previousImageId && previousImageId !== nextImageId) {
-      await deleteCmsImagesIfUnreferenced({
-        imageIds: [previousImageId],
-        prisma,
-      });
+    if (intent === "move-block-up" || intent === "move-block-down") {
+      if (blockRef.kind !== "page-block-id") {
+        throw new Response("move commands require a page-block-id ref", {
+          status: 400,
+        });
+      }
+
+      const mutableRef: MutableBlockRef = blockRef;
+      const command =
+        intent === "move-block-up"
+          ? commandBuilder.moveBlockUp(mutableRef)
+          : commandBuilder.moveBlockDown(mutableRef);
+
+      const result = await siteCmsPageService.applyPageCommand(command);
+
+      if (result.status === "conflict") {
+        return {
+          status: "conflict" as const,
+          conflictMessage:
+            "Move could not be applied — the page may have changed.",
+          editorModel: result.currentEditorModel,
+        };
+      }
+
+      return redirect(`/admin/pages/${pageKey}`);
     }
 
-    return redirect(`/admin/pages/${pageKey}`);
+    if (intent === "delete-block") {
+      if (blockRef.kind !== "page-block-id") {
+        throw new Response("delete command requires a page-block-id ref", {
+          status: 400,
+        });
+      }
+
+      const mutableRef: MutableBlockRef = blockRef;
+      const command = commandBuilder.deleteBlock(mutableRef);
+      const result = await siteCmsPageService.applyPageCommand(command);
+
+      if (result.status === "conflict") {
+        return {
+          status: "conflict" as const,
+          conflictMessage:
+            "Delete could not be applied — the block may be in a fixed slot.",
+          editorModel: result.currentEditorModel,
+        };
+      }
+
+      return redirect(`/admin/pages/${pageKey}`);
+    }
+
+    throw new Response(`Unknown intent: ${String(intent)}`, { status: 400 });
+  } finally {
+    await uploadResult.discardImage();
   }
-
-  if (intent === "move-block-up" || intent === "move-block-down") {
-    if (blockRef.kind !== "page-block-id") {
-      throw new Response("move commands require a page-block-id ref", {
-        status: 400,
-      });
-    }
-
-    const mutableRef: MutableBlockRef = blockRef;
-    const command =
-      intent === "move-block-up"
-        ? commandBuilder.moveBlockUp(mutableRef)
-        : commandBuilder.moveBlockDown(mutableRef);
-
-    const result = await siteCmsPageService.applyPageCommand(command);
-
-    if (result.status === "conflict") {
-      return {
-        status: "conflict" as const,
-        conflictMessage:
-          "Move could not be applied — the page may have changed.",
-        editorModel: result.currentEditorModel,
-      };
-    }
-
-    return redirect(`/admin/pages/${pageKey}`);
-  }
-
-  if (intent === "delete-block") {
-    if (blockRef.kind !== "page-block-id") {
-      throw new Response("delete command requires a page-block-id ref", {
-        status: 400,
-      });
-    }
-
-    const mutableRef: MutableBlockRef = blockRef;
-    const command = commandBuilder.deleteBlock(mutableRef);
-    const result = await siteCmsPageService.applyPageCommand(command);
-
-    if (result.status === "conflict") {
-      return {
-        status: "conflict" as const,
-        conflictMessage:
-          "Delete could not be applied — the block may be in a fixed slot.",
-        editorModel: result.currentEditorModel,
-      };
-    }
-
-    return redirect(`/admin/pages/${pageKey}`);
-  }
-
-  throw new Response(`Unknown intent: ${String(intent)}`, { status: 400 });
 }
 
 async function persistHeroUploadedImage(
   fileEntry: FormDataEntryValue | null,
+  upload: {
+    persistImage(file: File): Promise<string>;
+  },
 ): Promise<string | undefined> {
   if (!(fileEntry instanceof File) || fileEntry.size <= 0) {
     return undefined;
   }
 
-  const image = await prisma.image.create({
-    data: {
-      contentType: fileEntry.type || "application/octet-stream",
-      blob: Buffer.from(await fileEntry.arrayBuffer()),
-    },
-  });
-  return image.id;
+  return upload.persistImage(fileEntry);
 }
 
 function getUploadedHeroImageId(blockData: unknown): string | null {

--- a/app/routes/file.$fileId.tsx
+++ b/app/routes/file.$fileId.tsx
@@ -1,9 +1,6 @@
-import type { ComponentProps } from "react";
 import sharp, { type FitEnum } from "sharp";
 import invariant from "tiny-invariant";
 import { z } from "zod";
-
-import type { Route } from "./+types/file.$fileId";
 
 import { prisma } from "~/db.server";
 import { logger } from "~/logger.server";
@@ -11,7 +8,6 @@ import {
   fileStorage as cache,
   getStorageKey as getCacheKey,
 } from "~/utils/file-chache-storage.server";
-import { getImageUrl } from "~/utils/misc";
 
 const SearchParamsSchema = z.object({
   width: z.coerce.number().min(0).optional(),
@@ -21,57 +17,14 @@ const SearchParamsSchema = z.object({
 
 type SearchParams = z.infer<typeof SearchParamsSchema>;
 
-type ImageInputProps = {
-  imageId: string;
-  width: number;
-  height: number;
-} & Partial<Pick<SearchParams, "fit">>;
+type FileRouteLoaderArgs = {
+  request: Request;
+  params: {
+    fileId?: string;
+  };
+};
 
-type ImageProps = Omit<ComponentProps<"img">, "width" | "height" | "src"> &
-  ImageInputProps;
-
-export function OptimizedImage({
-  imageId,
-  width,
-  height,
-  fit = "cover",
-  ...props
-}: ImageProps) {
-  const breakPoints = [432, 648, 864, 1080];
-  const imageUrl = getImageUrl(imageId);
-  const aspect = width / height;
-
-  const searchParams = new URLSearchParams({
-    w: `${width}`,
-    h: `${height}`,
-    fit,
-  });
-
-  const srcSetUrls = breakPoints.map((w) => {
-    const h = w / aspect;
-    const searchParams = new URLSearchParams({
-      w: `${w}`,
-      h: `${h}`,
-      fit,
-    });
-
-    return `${imageUrl + "?" + searchParams.toString()} ${w}w`;
-  });
-
-  return (
-    <picture>
-      <img
-        srcSet={srcSetUrls.join(", ")}
-        src={imageUrl + "?" + searchParams.toString()}
-        width={width}
-        height={height}
-        {...props}
-      />
-    </picture>
-  );
-}
-
-export async function loader({ request, params }: Route.LoaderArgs) {
+export async function loader({ request, params }: FileRouteLoaderArgs) {
   const url = new URL(request.url);
   const searchParams = url.searchParams;
   const { fileId } = params;

--- a/app/routes/file.$fileId.tsx
+++ b/app/routes/file.$fileId.tsx
@@ -3,19 +3,16 @@ import invariant from "tiny-invariant";
 import { z } from "zod";
 
 import { prisma } from "~/db.server";
-import { logger } from "~/logger.server";
 import {
   fileStorage as cache,
   getStorageKey as getCacheKey,
 } from "~/utils/file-chache-storage.server";
 
 const SearchParamsSchema = z.object({
-  width: z.coerce.number().min(0).optional(),
-  height: z.coerce.number().min(0).optional(),
+  width: z.coerce.number().int().positive().optional(),
+  height: z.coerce.number().int().positive().optional(),
   fit: z.enum(["cover", "contain", "fill"]).optional().default("cover"),
 });
-
-type SearchParams = z.infer<typeof SearchParamsSchema>;
 
 type FileRouteLoaderArgs = {
   request: Request;
@@ -35,8 +32,6 @@ export async function loader({ request, params }: FileRouteLoaderArgs) {
     fit: searchParams.get("fit"),
   });
 
-  logger.info(JSON.stringify(options));
-
   if (!options.success) {
     // Params were malformed
     throw new Response("Bad request", {
@@ -49,28 +44,19 @@ export async function loader({ request, params }: FileRouteLoaderArgs) {
   const { width, height, fit } = options.data;
   const cacheKey = getCacheKey(`${fileId}-${width}-${height}-${fit}`);
 
-  logger.info(`Checking cache with: ${cacheKey}`);
-
   if (await cache.has(cacheKey)) {
     const fileStream = await cache.get(cacheKey);
     if (!fileStream) {
-      // Key exists but no file.
-      // Continue as if no cache exists
-      logger.info(`Cache miss with: ${cacheKey}`);
+      // Key exists but no file. Continue as if no cache exists.
     } else {
-      // Cache hit successful
-      logger.info(`Cache hit with: ${cacheKey}`);
       return new Response(fileStream.stream(), {
         headers: {
           "Content-Type": "image/webp",
           "Content-Disposition": `inline; filename="${params.fileId}"`,
           "Cache-Control": "public, max-age=31536000, immutable",
-          "Transfer-Encoding": "chunked",
         },
       });
     }
-  } else {
-    logger.info(`Cache miss with: ${cacheKey}`);
   }
 
   const file = await prisma.image.findUnique({ where: { id: fileId } });
@@ -79,24 +65,26 @@ export async function loader({ request, params }: FileRouteLoaderArgs) {
   const optimizedImage = await sharp(file.blob)
     .webp()
     .resize({
-      ...(width && { width: Number(width) }),
-      ...(height && { height: Number(height) }),
+      ...(width ? { width } : {}),
+      ...(height ? { height } : {}),
       fit: isAllowedFit(fit) ? fit : "cover",
     })
     .toBuffer();
 
-  const test = new Uint8Array(optimizedImage);
-  const testFile = new File([test], fileId);
+  const optimizedImageBytes = new Uint8Array(optimizedImage);
+  const optimizedImageFile = new File([optimizedImageBytes], fileId);
 
   // @ts-ignore
-  return new Response((await cache.put(cacheKey, testFile)).stream(), {
-    headers: {
-      "Content-Type": "image/webp",
-      "Content-Disposition": `inline; filename="${params.fileId}"`,
-      "Cache-Control": "public, max-age=31536000, immutable",
-      "Transfer-Encoding": "chunked",
+  return new Response(
+    (await cache.put(cacheKey, optimizedImageFile)).stream(),
+    {
+      headers: {
+        "Content-Type": "image/webp",
+        "Content-Disposition": `inline; filename="${params.fileId}"`,
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
     },
-  });
+  );
 }
 
 function isAllowedFit(s: string | null): s is FitEnum[keyof FitEnum] {

--- a/cypress/e2e/admin-hero-editor.cy.ts
+++ b/cypress/e2e/admin-hero-editor.cy.ts
@@ -71,9 +71,8 @@ describe("admin cms hero block editor", () => {
     cy.visitAndCheck("/admin/pages/home");
     cy.findByRole("button", { name: /save page/i }).click();
 
-    cy.findByLabelText(/^headline$/i)
-      .clear()
-      .type("Edited headline with invalid CTA");
+    cy.findByLabelText(/^headline$/i).clear();
+    cy.findByLabelText(/^headline$/i).type("Edited headline with invalid CTA");
     cy.findByLabelText(/^cta label$/i).clear();
 
     cy.findByRole("button", { name: /save block/i }).click();
@@ -174,5 +173,55 @@ describe("admin cms hero block editor", () => {
 
     cy.findByRole("button", { name: /save block/i }).click();
     cy.findByText(FILE_TOO_LARGE_ERROR).should("be.visible");
+  });
+
+  it("requires an explicit accessibility choice before replacing the hero image", () => {
+    materializeHomePage();
+
+    cy.findByLabelText(/^image action$/i).select("replace");
+    cy.findByLabelText(/^upload image file$/i).selectFile(
+      VALID_UPLOAD_FIXTURE_PATH,
+      {
+        force: true,
+      },
+    );
+
+    cy.findByRole("button", { name: /save block/i }).click();
+    cy.findByText(/image accessibility choice is required/i).should(
+      "be.visible",
+    );
+  });
+
+  it("updates uploaded hero accessibility metadata without requiring a second upload", () => {
+    materializeHomePage();
+    cy.findByLabelText(/^image action$/i).select("replace");
+    cy.findByLabelText(/^upload image file$/i).selectFile(
+      VALID_UPLOAD_FIXTURE_PATH,
+      {
+        force: true,
+      },
+    );
+    cy.findByLabelText(/^image accessibility$/i).select("descriptive");
+    cy.findByLabelText(/^image alt text$/i)
+      .clear()
+      .type("Original hero alt text");
+
+    cy.findByRole("button", { name: /save block/i }).click();
+    cy.findByText(/persisted page/i).should("be.visible");
+
+    cy.visitAndCheck("/admin/pages/home");
+    cy.findByLabelText(/^image action$/i).should("have.value", "keep");
+    cy.findByLabelText(/^image accessibility$/i).select("descriptive");
+    cy.findByLabelText(/^image alt text$/i)
+      .clear()
+      .type("Updated hero alt text");
+
+    cy.findByRole("button", { name: /save block/i }).click();
+    cy.findByText(/persisted page/i).should("be.visible");
+
+    cy.visitAndCheck("/");
+    cy.get("section img")
+      .first()
+      .should("have.attr", "alt", "Updated hero alt text");
   });
 });

--- a/cypress/e2e/admin-hero-editor.cy.ts
+++ b/cypress/e2e/admin-hero-editor.cy.ts
@@ -1,4 +1,24 @@
-import { runUploadDbCommand } from "../support/upload-test-utils";
+import {
+  FILE_TOO_LARGE_ERROR,
+  runUploadDbCommand,
+  uploadFileInput,
+  VALID_UPLOAD_FIXTURE_PATH,
+  ZOD_LIMIT_BYTES,
+} from "../support/upload-test-utils";
+
+function materializeHomePage() {
+  cy.visitAndCheck("/admin/pages/home");
+  cy.findByRole("button", { name: /save page/i }).click();
+  cy.findByText(/persisted page/i).should("be.visible");
+}
+
+function setHeroImageReplacement(file: string | Cypress.FileReferenceObject) {
+  cy.findByLabelText(/^image action$/i).select("replace");
+  cy.findByLabelText(/^upload image file$/i).selectFile(file, {
+    force: true,
+  });
+  cy.findByLabelText(/^image accessibility$/i).select("decorative");
+}
 
 describe("admin cms hero block editor", () => {
   beforeEach(() => {
@@ -120,5 +140,39 @@ describe("admin cms hero block editor", () => {
     // Move-up and delete buttons should not exist for the fixed hero block
     cy.findByRole("button", { name: /move up/i }).should("not.exist");
     cy.findByRole("button", { name: /delete block/i }).should("not.exist");
+  });
+
+  it("serves a non-broken homepage hero image after uploading a CMS image", () => {
+    materializeHomePage();
+    setHeroImageReplacement(VALID_UPLOAD_FIXTURE_PATH);
+
+    cy.findByRole("button", { name: /save block/i }).click();
+    cy.findByText(/persisted page/i).should("be.visible");
+
+    cy.visitAndCheck("/");
+    cy.get("section img")
+      .first()
+      .should("have.attr", "src")
+      .and("match", /^\/file\//)
+      .then((src) => {
+        cy.request(String(src)).its("status").should("eq", 200);
+      });
+
+    cy.get("section img")
+      .first()
+      .should(($img) => {
+        const image = $img[0] as HTMLImageElement | undefined;
+        expect(image?.naturalWidth ?? 0).to.be.greaterThan(0);
+      });
+  });
+
+  it("shows a validation error when the uploaded hero image is larger than 3MB", () => {
+    materializeHomePage();
+    setHeroImageReplacement(
+      uploadFileInput(ZOD_LIMIT_BYTES + 1, { fileName: "zod-too-large.jpg" }),
+    );
+
+    cy.findByRole("button", { name: /save block/i }).click();
+    cy.findByText(FILE_TOO_LARGE_ERROR).should("be.visible");
   });
 });


### PR DESCRIPTION
## Summary
- add CMS-managed hero image replacement with explicit decorative vs descriptive accessibility authoring
- allow admins to update uploaded hero image accessibility metadata without re-uploading the image
- clean up unreferenced CMS-owned hero images after replace, remove, and delete flows, and tighten responsive image delivery

## Testing
- `npm test -- --run app/components/optimized-image.test.tsx app/features/cms/blocks/hero/editor-schema.test.ts app/features/cms/blocks/hero/editor.test.tsx app/features/cms/cms-image-lifecycle.server.test.ts app/features/cms/page-service.server.test.ts app/features/cms/public-page-renderer.test.tsx`
- `npx cypress run --spec cypress/e2e/admin-pages.cy.ts`
- `npx cypress run --spec cypress/e2e/admin-hero-editor.cy.ts`

Fixes #365
