### PR TITLE
feat(cms): implement optimistic concurrency, reset-to-defaults, and e2e acceptance flow

### DIFF
--- a/app/features/cms/diagnostics.ts
+++ b/app/features/cms/diagnostics.ts
@@ -7,6 +7,7 @@ export const cmsDiagnosticCodes = {
   pageMigrated: "page/migrated",
   pagePublicOmittedBrokenBlocks: "page/public-omitted-broken-blocks",
   pagePublicFallbackDefaults: "page/public-fallback-defaults",
+  mutationStaleWrite: "mutation/stale-write",
 } as const;
 
 export type CmsDiagnosticCode =
@@ -146,6 +147,14 @@ export function createPageMigratedDiagnostic(pageKey: string): CmsDiagnostic {
   return {
     code: cmsDiagnosticCodes.pageMigrated,
     message: `Persisted page "${pageKey}" was migrated at read time.`,
+  };
+}
+
+export function createMutationStaleWriteDiagnostic(): CmsDiagnostic {
+  return {
+    code: cmsDiagnosticCodes.mutationStaleWrite,
+    message:
+      "Page changed since last load. Refreshed with current values — please review and save again.",
   };
 }
 

--- a/app/features/cms/page-commands.ts
+++ b/app/features/cms/page-commands.ts
@@ -61,13 +61,20 @@ export type AddBlockCommand = {
   data: unknown;
 };
 
+export type ResetPageCommand = {
+  type: "reset-page";
+  pageKey: PageKey;
+  baseRevision: Revision | null;
+};
+
 export type PageCommand =
   | SetPageMetaCommand
   | SetBlockDataCommand
   | MoveBlockUpCommand
   | MoveBlockDownCommand
   | DeleteBlockCommand
-  | AddBlockCommand;
+  | AddBlockCommand
+  | ResetPageCommand;
 
 export type PageCommandBuilder = {
   setBlockData(
@@ -84,6 +91,7 @@ export type PageCommandBuilder = {
     blockVersion: number,
     data: unknown,
   ): AddBlockCommand;
+  resetPage(): ResetPageCommand;
 };
 
 export function createPageCommandBuilder(
@@ -120,6 +128,9 @@ export function createPageCommandBuilder(
         blockVersion,
         data,
       };
+    },
+    resetPage() {
+      return { type: "reset-page", pageKey, baseRevision };
     },
   };
 }

--- a/app/features/cms/page-service.server.test.ts
+++ b/app/features/cms/page-service.server.test.ts
@@ -144,6 +144,11 @@ function createMemoryPageStore(): CmsPageStore & {
         persistedPage: structuredClone(page),
       };
     },
+    async deletePage(pageKey) {
+      if (page && page.pageKey === pageKey) {
+        page = null;
+      }
+    },
   };
 }
 
@@ -2389,5 +2394,181 @@ describe("createCmsPageService — add-block command", () => {
       },
       variant: "default",
     });
+  });
+});
+
+describe("createCmsPageService — reset-page command", () => {
+  async function setupPersisted() {
+    const store = createMemoryPageStore();
+    const service = createCmsPageService({
+      catalog: siteCmsCatalog,
+      pageStore: store,
+    });
+
+    const result = await service.applyPageCommand({
+      type: "set-page-meta",
+      pageKey: "home",
+      baseRevision: null,
+      title: "persisted title",
+      description: "persisted description",
+    });
+
+    if (result.status !== "saved") throw new Error("setup: expected saved");
+
+    return { service, store, revision: result.editorModel.status.revision! };
+  }
+
+  test("reset-page on default-backed page with null baseRevision returns saved with materialization reset", async () => {
+    const store = createMemoryPageStore();
+    const service = createCmsPageService({
+      catalog: siteCmsCatalog,
+      pageStore: store,
+    });
+
+    const result = await service.applyPageCommand({
+      type: "reset-page",
+      pageKey: "home",
+      baseRevision: null,
+    });
+
+    expect(result.status).toBe("saved");
+    if (result.status !== "saved") return;
+    expect(result.materialization).toBe("reset");
+    expect(result.editorModel.status.kind).toBe("default-backed");
+    expect(store.peek("home")).toBeNull();
+  });
+
+  test("reset-page on default-backed page with non-null baseRevision returns conflict with mutationStaleWrite diagnostic", async () => {
+    const store = createMemoryPageStore();
+    const service = createCmsPageService({
+      catalog: siteCmsCatalog,
+      pageStore: store,
+    });
+
+    const result = await service.applyPageCommand({
+      type: "reset-page",
+      pageKey: "home",
+      baseRevision: 1,
+    });
+
+    expect(result.status).toBe("conflict");
+    if (result.status !== "conflict") return;
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: cmsDiagnosticCodes.mutationStaleWrite }),
+    );
+  });
+
+  test("reset-page on persisted page with matching revision deletes page and returns saved with materialization reset", async () => {
+    const { service, store, revision } = await setupPersisted();
+
+    const result = await service.applyPageCommand({
+      type: "reset-page",
+      pageKey: "home",
+      baseRevision: revision,
+    });
+
+    expect(result.status).toBe("saved");
+    if (result.status !== "saved") return;
+    expect(result.materialization).toBe("reset");
+    expect(result.editorModel.status.kind).toBe("default-backed");
+    expect(result.editorModel.status.revision).toBeNull();
+    expect(store.peek("home")).toBeNull();
+  });
+
+  test("reset-page on persisted page with stale revision returns conflict with mutationStaleWrite diagnostic", async () => {
+    const { service } = await setupPersisted();
+
+    const result = await service.applyPageCommand({
+      type: "reset-page",
+      pageKey: "home",
+      baseRevision: 999,
+    });
+
+    expect(result.status).toBe("conflict");
+    if (result.status !== "conflict") return;
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: cmsDiagnosticCodes.mutationStaleWrite }),
+    );
+  });
+
+  test("reset-page on persisted page with null baseRevision returns conflict with mutationStaleWrite diagnostic", async () => {
+    const { service } = await setupPersisted();
+
+    const result = await service.applyPageCommand({
+      type: "reset-page",
+      pageKey: "home",
+      baseRevision: null,
+    });
+
+    expect(result.status).toBe("conflict");
+    if (result.status !== "conflict") return;
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: cmsDiagnosticCodes.mutationStaleWrite }),
+    );
+  });
+});
+
+describe("createCmsPageService — mutation stale-write diagnostics", () => {
+  async function setupPersisted() {
+    const store = createMemoryPageStore();
+    const service = createCmsPageService({
+      catalog: siteCmsCatalog,
+      pageStore: store,
+    });
+
+    const result = await service.applyPageCommand({
+      type: "set-page-meta",
+      pageKey: "home",
+      baseRevision: null,
+      title: "title",
+      description: "desc",
+    });
+
+    if (result.status !== "saved") throw new Error("setup: expected saved");
+
+    return { service, store, revision: result.editorModel.status.revision! };
+  }
+
+  test("set-page-meta with stale revision returns conflict with mutationStaleWrite diagnostic", async () => {
+    const { service } = await setupPersisted();
+
+    const result = await service.applyPageCommand({
+      type: "set-page-meta",
+      pageKey: "home",
+      baseRevision: 999,
+      title: "new title",
+      description: "new desc",
+    });
+
+    expect(result.status).toBe("conflict");
+    if (result.status !== "conflict") return;
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: cmsDiagnosticCodes.mutationStaleWrite }),
+    );
+  });
+
+  test("set-block-data with stale revision returns conflict with mutationStaleWrite diagnostic", async () => {
+    const { service, store } = await setupPersisted();
+    const heroBlock = store.peek("home")!.blocks[0];
+
+    const result = await service.applyPageCommand({
+      type: "set-block-data",
+      pageKey: "home",
+      baseRevision: 999,
+      ref: {
+        kind: "page-block-id",
+        pageBlockId: heroBlock.pageBlockId!,
+        position: 0,
+      },
+      blockType: "hero",
+      blockVersion: 1,
+      data: heroBlock.data,
+    });
+
+    expect(result.status).toBe("conflict");
+    if (result.status !== "conflict") return;
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: cmsDiagnosticCodes.mutationStaleWrite }),
+    );
   });
 });

--- a/app/features/cms/page-service.server.ts
+++ b/app/features/cms/page-service.server.ts
@@ -14,6 +14,7 @@ import {
   createBlockMigratedDiagnostic,
   createBlockUnsupportedTypeDiagnostic,
   createBlockUnsupportedVersionDiagnostic,
+  createMutationStaleWriteDiagnostic,
   createPageMigratedDiagnostic,
   createPagePublicFallbackDefaultsDiagnostic,
   createPagePublicOmittedBrokenBlocksDiagnostic,
@@ -30,6 +31,7 @@ import type {
   MoveBlockUpCommand,
   MutableBlockRef,
   PageCommand,
+  ResetPageCommand,
   SetBlockDataCommand,
   SetPageMetaCommand,
 } from "./page-commands";
@@ -48,6 +50,7 @@ export type {
   MutableBlockRef,
   PageCommand,
   PageCommandBuilder,
+  ResetPageCommand,
   SetBlockDataCommand,
   SetPageMetaCommand,
 } from "./page-commands";
@@ -114,12 +117,14 @@ export type CmsPageStore = {
     description: string;
     blocks: readonly BlockInstance[];
   }): Promise<WriteSuccess | WriteConflict>;
+  /** Delete the persisted page record, returning the page to default-backed behavior. */
+  deletePage(pageKey: PageKey): Promise<void>;
 };
 
 export type ApplyPageCommandResult =
   | {
       status: "saved";
-      materialization: "created" | "updated";
+      materialization: "created" | "updated" | "reset";
       editorModel: EditorModel;
     }
   | {
@@ -403,7 +408,7 @@ export function createCmsPageService({
         return {
           status: "conflict",
           currentEditorModel: currentPage,
-          diagnostics: [],
+          diagnostics: [createMutationStaleWriteDiagnostic()],
         };
       }
     } else {
@@ -414,7 +419,7 @@ export function createCmsPageService({
         return {
           status: "conflict",
           currentEditorModel: currentPage,
-          diagnostics: [],
+          diagnostics: [createMutationStaleWriteDiagnostic()],
         };
       }
     }
@@ -674,7 +679,7 @@ export function createCmsPageService({
         return {
           status: "conflict",
           currentEditorModel: currentPage,
-          diagnostics: [],
+          diagnostics: [createMutationStaleWriteDiagnostic()],
         };
       }
 
@@ -713,7 +718,7 @@ export function createCmsPageService({
       return {
         status: "conflict",
         currentEditorModel: currentPage,
-        diagnostics: [],
+        diagnostics: [createMutationStaleWriteDiagnostic()],
       };
     }
 
@@ -751,6 +756,46 @@ export function createCmsPageService({
         command.pageKey,
         writeResult.persistedPage,
       ),
+    };
+  };
+
+  const applyResetPage = async (
+    command: ResetPageCommand,
+  ): Promise<ApplyPageCommandResult> => {
+    const currentPage = await readResolvedPage(command.pageKey);
+
+    if (currentPage.status.kind === "default-backed") {
+      if (command.baseRevision !== null) {
+        return {
+          status: "conflict",
+          currentEditorModel: currentPage,
+          diagnostics: [createMutationStaleWriteDiagnostic()],
+        };
+      }
+      return {
+        status: "saved",
+        materialization: "reset",
+        editorModel: currentPage,
+      };
+    }
+
+    if (
+      command.baseRevision === null ||
+      command.baseRevision !== currentPage.status.revision
+    ) {
+      return {
+        status: "conflict",
+        currentEditorModel: currentPage,
+        diagnostics: [createMutationStaleWriteDiagnostic()],
+      };
+    }
+
+    await pageStore.deletePage(command.pageKey);
+
+    return {
+      status: "saved",
+      materialization: "reset",
+      editorModel: defaultBackedPage(command.pageKey),
     };
   };
 
@@ -855,6 +900,8 @@ export function createCmsPageService({
           return applyDeleteBlock(command);
         case "add-block":
           return applyAddBlock(command);
+        case "reset-page":
+          return applyResetPage(command);
       }
     },
   };

--- a/app/features/cms/page-store.server.ts
+++ b/app/features/cms/page-store.server.ts
@@ -171,6 +171,9 @@ export function createPrismaCmsPageStore({
         };
       });
     },
+    async deletePage(pageKey) {
+      await prisma.page.delete({ where: { pageKey } });
+    },
     async updatePageMeta({ pageKey, expectedRevision, title, description }) {
       return prisma.$transaction(async (tx) => {
         const existingPage = await tx.page.findUnique({

--- a/app/routes/admin.pages.$pageKey.tsx
+++ b/app/routes/admin.pages.$pageKey.tsx
@@ -59,8 +59,10 @@ import {
   createPageCommandBuilder,
   type MutableBlockRef,
 } from "~/features/cms/page-commands";
-import type { PageCommand } from "~/features/cms/page-service.server";
-import type { Diagnostic } from "~/features/cms/page-service.server";
+import type {
+  Diagnostic,
+  PageCommand,
+} from "~/features/cms/page-service.server";
 import { formatPageStatus } from "~/features/cms/page-status";
 import { siteCmsCatalog } from "~/features/cms/site-catalog";
 import { siteLinkTargetRegistry } from "~/features/cms/site-link-targets";
@@ -110,6 +112,16 @@ function parseBaseRevision(raw: FormDataEntryValue | null): number | null {
   if (typeof raw !== "string" || raw === "") return null;
   const n = Number(raw);
   return Number.isInteger(n) && n >= 0 ? n : null;
+}
+
+function conflictMessageFromDiagnostics(
+  diagnostics: readonly Diagnostic[],
+  fallback: string,
+): string {
+  const staleWrite = diagnostics.find(
+    (d) => d.code === cmsDiagnosticCodes.mutationStaleWrite,
+  );
+  return staleWrite ? staleWrite.message : fallback;
 }
 
 // ─── Loader ───────────────────────────────────────────────────────────────────
@@ -166,8 +178,10 @@ export async function action({ request, params }: Route.ActionArgs) {
       if (result.status === "conflict") {
         return {
           status: "conflict" as const,
-          conflictMessage:
-            "This page was changed by someone else. The editor has been refreshed with the current values - please review and save again.",
+          conflictMessage: conflictMessageFromDiagnostics(
+            result.diagnostics,
+            "Page could not be saved — please refresh and try again.",
+          ),
           editorModel: result.currentEditorModel,
         };
       }
@@ -219,9 +233,29 @@ export async function action({ request, params }: Route.ActionArgs) {
       if (addResult.status === "conflict") {
         return {
           status: "conflict" as const,
-          conflictMessage:
+          conflictMessage: conflictMessageFromDiagnostics(
+            addResult.diagnostics,
             "Block could not be added — the page may have changed.",
+          ),
           editorModel: addResult.currentEditorModel,
+        };
+      }
+
+      return redirect(`/admin/pages/${pageKey}`);
+    }
+
+    if (intent === "reset-page") {
+      const command = commandBuilder.resetPage();
+      const result = await siteCmsPageService.applyPageCommand(command);
+
+      if (result.status === "conflict") {
+        return {
+          status: "conflict" as const,
+          conflictMessage: conflictMessageFromDiagnostics(
+            result.diagnostics,
+            "Reset could not be applied — the page may have changed.",
+          ),
+          editorModel: result.currentEditorModel,
         };
       }
 
@@ -360,8 +394,10 @@ export async function action({ request, params }: Route.ActionArgs) {
           return {
             status: "block-conflict" as const,
             blockRef: serializedBlockRef,
-            conflictMessage:
+            conflictMessage: conflictMessageFromDiagnostics(
+              heroResult.diagnostics,
               "Block could not be saved — please refresh and retry.",
+            ),
             editorModel: heroResult.currentEditorModel,
           };
         }
@@ -425,8 +461,10 @@ export async function action({ request, params }: Route.ActionArgs) {
           return {
             status: "block-conflict" as const,
             blockRef: serializedBlockRef,
-            conflictMessage:
+            conflictMessage: conflictMessageFromDiagnostics(
+              textSectionResult.diagnostics,
               "Block could not be saved — please refresh and retry.",
+            ),
             editorModel: textSectionResult.currentEditorModel,
           };
         }
@@ -537,8 +575,10 @@ export async function action({ request, params }: Route.ActionArgs) {
           return {
             status: "block-conflict" as const,
             blockRef: serializedBlockRef,
-            conflictMessage:
+            conflictMessage: conflictMessageFromDiagnostics(
+              imageResult.diagnostics,
               "Block could not be saved — please refresh and retry.",
+            ),
             editorModel: imageResult.currentEditorModel,
           };
         }
@@ -574,8 +614,10 @@ export async function action({ request, params }: Route.ActionArgs) {
       if (result.status === "conflict") {
         return {
           status: "conflict" as const,
-          conflictMessage:
+          conflictMessage: conflictMessageFromDiagnostics(
+            result.diagnostics,
             "Move could not be applied — the page may have changed.",
+          ),
           editorModel: result.currentEditorModel,
         };
       }
@@ -599,8 +641,10 @@ export async function action({ request, params }: Route.ActionArgs) {
       if (result.status === "conflict") {
         return {
           status: "conflict" as const,
-          conflictMessage:
+          conflictMessage: conflictMessageFromDiagnostics(
+            result.diagnostics,
             "Delete could not be applied — the block may be in a fixed slot.",
+          ),
           editorModel: result.currentEditorModel,
         };
       }
@@ -764,7 +808,9 @@ export default function AdminPageEditorRoute() {
   const pageRule = siteCmsCatalog.getPageRule(displayEditorModel.pageKey);
   const requiredLeadingCount = pageRule.requiredLeadingBlockTypes?.length ?? 0;
   const blocks = displayEditorModel.pageSnapshot.blocks;
-  const defaultSnapshot = siteCmsCatalog.readPageSnapshot(displayEditorModel.pageKey);
+  const defaultSnapshot = siteCmsCatalog.readPageSnapshot(
+    displayEditorModel.pageKey,
+  );
   const defaultBlockDataByType = new Map<BlockType, unknown[]>();
   for (const defaultBlock of defaultSnapshot.blocks) {
     const candidates = defaultBlockDataByType.get(defaultBlock.type);
@@ -957,6 +1003,10 @@ export default function AdminPageEditorRoute() {
             </form>
           ))}
       </section>
+
+      {displayEditorModel.status.kind === "persisted" ? (
+        <ResetToDefaultsSection revision={revision} />
+      ) : null}
     </main>
   );
 }
@@ -1106,5 +1156,43 @@ function BrokenBlockCard({
         ) : null}
       </div>
     </div>
+  );
+}
+
+function ResetToDefaultsSection({ revision }: { revision: number | null }) {
+  return (
+    <section className="flex flex-col gap-3 border-t pt-6">
+      <h2 className="text-lg font-semibold">Reset to defaults</h2>
+      <p className="text-muted-foreground text-sm">
+        Discard all persisted CMS content for this page. The page will return to
+        code-defined defaults until the next successful save.
+      </p>
+      <details className="rounded-md border border-dashed p-4">
+        <summary className="text-destructive cursor-pointer font-medium">
+          Confirm reset to defaults
+        </summary>
+        <div className="mt-4 flex flex-col gap-3">
+          <p className="text-sm">
+            This action cannot be undone. All customized content will be
+            removed.
+          </p>
+          <form method="post">
+            <input type="hidden" name="intent" value="reset-page" />
+            <input
+              type="hidden"
+              name="baseRevision"
+              value={revision === null ? "" : String(revision)}
+            />
+            <Button
+              type="submit"
+              variant="outline"
+              className="text-destructive"
+            >
+              Reset to defaults
+            </Button>
+          </form>
+        </div>
+      </details>
+    </section>
   );
 }

--- a/cypress/e2e/admin-pages.cy.ts
+++ b/cypress/e2e/admin-pages.cy.ts
@@ -73,10 +73,13 @@ describe("admin cms pages", () => {
     cy.visitAndCheck("/admin/pages/home");
     cy.findByText(/recovered to defaults/i).should("be.visible");
     cy.findByText(/revision 1/i).should("be.visible");
-    cy.findByLabelText(/^title$/i).should("have.value", "broken persisted title");
-    cy.findByText(/recovered editor defaults from invalid persisted data/i).should(
-      "be.visible",
+    cy.findByLabelText(/^title$/i).should(
+      "have.value",
+      "broken persisted title",
     );
+    cy.findByText(
+      /recovered editor defaults from invalid persisted data/i,
+    ).should("be.visible");
     cy.get('form[id^="hero-block-editor-"]').within(() => {
       cy.findByLabelText(/^headline$/i)
         .should("have.value", "moku pona")
@@ -110,7 +113,7 @@ describe("admin cms pages", () => {
 
     cy.findByRole("button", { name: /save page/i }).click();
 
-    cy.findByText(/changed by someone else/i).should("be.visible");
+    cy.findByText(/page changed since last load/i).should("be.visible");
     cy.findByText(/revision 1/i).should("be.visible");
     cy.findByLabelText(/^title$/i).should("have.value", "remote current title");
     cy.findByLabelText(/^description$/i).should(
@@ -124,5 +127,59 @@ describe("admin cms pages", () => {
     cy.findByRole("button", { name: /save page/i }).click();
 
     cy.findByText(/revision 2/i).should("be.visible");
+  });
+
+  it("resets a persisted page to defaults and verifies the public page reverts", () => {
+    // First materialize the home page with a custom title
+    runUploadDbCommand("save-page-meta", {
+      pageKey: "home",
+      title: "Custom CMS Title",
+      description: "Custom CMS description",
+    });
+
+    // Verify the custom title is live on the public page
+    cy.visitAndCheck("/");
+    cy.title().should("eq", "Custom CMS Title");
+
+    // Now reset to defaults in admin
+    cy.visitAndCheck("/admin/pages/home");
+    cy.findByText(/persisted page/i).should("be.visible");
+    cy.findByText(/confirm reset to defaults/i).click();
+    cy.findByRole("button", { name: /reset to defaults/i }).click();
+
+    // After reset, page should be default-backed
+    cy.findByText(/default-backed page/i).should("be.visible");
+    cy.findByText(/reset to defaults/i).should("not.exist");
+
+    // Public page should revert to code defaults
+    cy.visitAndCheck("/");
+    cy.title().should("not.eq", "Custom CMS Title");
+  });
+
+  it("editing home through admin updates the public page end-to-end with diagnostic-driven feedback", () => {
+    cy.visitAndCheck("/admin/pages/home");
+    cy.findByText(/default-backed page/i).should("be.visible");
+
+    // Save a unique title to materialize the page
+    const uniqueTitle = `E2E Home Title ${Date.now()}`;
+    cy.findByLabelText(/^title$/i)
+      .clear()
+      .type(uniqueTitle);
+    cy.findByLabelText(/^description$/i)
+      .clear()
+      .type("e2e description");
+    cy.findByRole("button", { name: /save page/i }).click();
+
+    cy.findByText(/persisted page/i).should("be.visible");
+    cy.findByText(/revision 1/i).should("be.visible");
+
+    // Verify the public page reflects the saved content
+    cy.visitAndCheck("/");
+    cy.title().should("eq", uniqueTitle);
+    cy.get('meta[name="description"]').should(
+      "have.attr",
+      "content",
+      "e2e description",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Adds `mutation/stale-write` diagnostic and routes conflict messages through `conflictMessageFromDiagnostics` so all mutation feedback is driven from stable diagnostic outcomes rather than ad hoc strings
- Adds `ResetPageCommand` with concurrency-safe revision check; deletes the persisted page record (using `prisma.page.delete` on the unique key) and returns the editor to default-backed state
- Adds `deletePage` to `CmsPageStore` interface and Prisma implementation
- Adds `ResetToDefaultsSection` UI with `<details>`/`<summary>` confirmation pattern; fixes `reset-page` intent handler placement (must precede the `blockRef` guard)
- Adds Cypress E2E flows: reset to defaults verifies public page reverts to code defaults; end-to-end home edit updates the public page with diagnostic-driven feedback

Closes #369
Part of #361

## Test plan

- [x] All unit tests pass (`npm run test`)
- [x] All E2E tests pass (`npm run test:e2e:run`) — including the two new `admin-pages.cy.ts` flows
- [x] Typecheck passes (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)